### PR TITLE
feat: approved 상태에 따른 PR의 라벨 추가

### DIFF
--- a/.github/workflows/review-status-labeling.yml
+++ b/.github/workflows/review-status-labeling.yml
@@ -1,9 +1,6 @@
 name: 'Review Status Labeling'
 on:
   pull_request:
-    branches: [main]
-    paths:
-      - '**'
     types: [opened, edited, reopened, ready_for_review]
   pull_request_review:
     types: [submitted, edited]

--- a/.github/workflows/review-status-labeling.yml
+++ b/.github/workflows/review-status-labeling.yml
@@ -1,0 +1,92 @@
+name: 'Review Status Labeling'
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - '**'
+    types: [opened, edited, reopened, ready_for_review]
+  pull_request_review:
+    types: [submitted, edited]
+
+jobs:
+  labeler:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out the repository
+        uses: actions/checkout@v2
+
+      - name: Count Approvals
+        id: count_approvals
+        uses: actions/github-script@v6
+        with:
+          github-token: ${{ secrets.ACTIONS_TOKEN }}
+          script: |
+            const reviewsResponse = await github.rest.pulls.listReviews({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.issue.number
+            });
+
+            const approvedReviews = reviewsResponse.data.filter(review => review.state === 'APPROVED');
+
+            return approvedReviews.length;
+
+      - name: Get Labels
+        id: get_labels
+        uses: actions/github-script@v6
+        with:
+          github-token: ${{ secrets.ACTIONS_TOKEN }}
+          script: |
+            const labelsResponse = await github.rest.issues.listLabelsOnIssue({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+            });
+
+            return labelsResponse.data.map(label => label.name);
+
+      - name: Apply Labels
+        uses: actions/github-script@v6
+        with:
+          github-token: ${{ secrets.ACTIONS_TOKEN }}
+          script: |
+            const labelNameList = ${{ steps.get_labels.outputs.result }};
+
+            if (${{ steps.count_approvals.outputs.result }} === 0) {
+              if (labelNameList.includes('Approved 🆗') === true) {
+                await github.rest.issues.removeLabel({
+                  issue_number: context.issue.number,
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  name: 'Approved 🆗'
+                });
+              }
+
+              if (labelNameList.length === 0 || labelNameList.includes('Review Plz🙏') === false) {
+                await github.rest.issues.addLabels({
+                  issue_number: context.issue.number,
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  labels: ['Review Plz🙏']
+                });
+              }
+            } else {
+              if (labelNameList.includes('Review Plz🙏') === true) {
+                await github.rest.issues.removeLabel({
+                  issue_number: context.issue.number,
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  name: 'Review Plz🙏'
+                });
+              }
+
+              if (labelNameList.includes('Approved 🆗') === false) {
+                await github.rest.issues.addLabels({
+                  issue_number: context.issue.number,
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  labels: ['Approved 🆗']
+                });
+              }
+            }


### PR DESCRIPTION
<!-- 작성 예시 -->
<!-- # 어떤 문제가 발생했나요? -->
<!-- - 간략한 문제 설명 -->
<!-- - 문제 관련 링크 등등 -->
<!-- Ex) React v18 version update에 후 테스트에서 에러가 발생합니다.
  react-testing-library의 버전이 호환이 되지않아서 문제입니다. -->

<!-- # 어떻게 해결했나요? -->
<!-- - 동작 방식 등 수정힌 코드에 대한 설명 -->
<!-- Ex) react-testing-library의 버전을 업데이트하고, react-test-renderer를 v18을 사용할 수 있도록 dev dependency로 설치해주었습니다. -->

<!-- # 이미지 첨부 (Option) -->
<!-- - 이번 PR의 동작 이해를 돕는 GIF나 이미지 파일 첨부! -->
<!-- - 만약 없다면, NA 혹은 비워둡시다~ -->

<!-- # 유의할 점 (Option) -->
<!-- - 추가적으로 고민중이거나 조언을 구하고 싶은 내용, 어떤 것을 중점으로 리뷰를 해줬으면 좋겠는지 등등 작성 -->
<!-- - 만약 없다면, NA 혹은 비워둡시다~ -->

## 🤔 어떤 문제가 발생했나요?

- PR의 리뷰 진행 상태를 보기 위해서 항상 PR을 클릭해서 확인해보아야 한다.

## 🎉 어떻게 해결했나요?

- GitHub Actions의 workflow에서 PR의 Approved 수를 카운트하여 라벨링을 통해 바로 확인할 수 있도록 하였습니다.

### 📷 이미지 첨부 (Option)

- NA

### ⚠️ 유의할 점! (Option)

- NA

<!-- PR merge시 닫을 이슈가 있다면, 번호를 작성해주세요 -->
<!-- Ex) close #12 -->
