### PR TITLE
chore: 공용 button 컴포넌트 작성 및 스토리북 설정을 변경했습니다.

### DIFF
--- a/.github/workflows/deploy-storybook.yml
+++ b/.github/workflows/deploy-storybook.yml
@@ -36,6 +36,9 @@ jobs:
         if: steps.cache.outputs.cache-hit != 'true'
         run: pnpm install
 
+      - name: Generate CSS
+        run: pnpm panda cssgen
+
       - name: Publish to chromatic
         id: chromatic
         uses: chromaui/action@v1

--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -1,4 +1,5 @@
 import type { StorybookConfig } from '@storybook/nextjs';
+import path from 'path';
 
 const config: StorybookConfig = {
   stories: ['../**/*.mdx', '../**/*.stories.@(js|jsx|mjs|ts|tsx)'],
@@ -13,5 +14,15 @@ const config: StorybookConfig = {
     name: '@storybook/nextjs',
     options: {},
   },
+  webpackFinal: async (config) => {
+    if (config.resolve) {
+      config.resolve.alias = {
+        ...config.resolve.alias,
+        '@': path.resolve(__dirname, '..'),
+      };
+    }
+    return config;
+  },
 };
+
 export default config;

--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -1,5 +1,4 @@
 import type { StorybookConfig } from '@storybook/nextjs';
-import path from 'path';
 
 const config: StorybookConfig = {
   stories: ['../**/*.mdx', '../**/*.stories.@(js|jsx|mjs|ts|tsx)'],
@@ -13,15 +12,6 @@ const config: StorybookConfig = {
   framework: {
     name: '@storybook/nextjs',
     options: {},
-  },
-  webpackFinal: async (config) => {
-    if (config.resolve) {
-      config.resolve.alias = {
-        ...config.resolve.alias,
-        '@': path.resolve(__dirname, '..'),
-      };
-    }
-    return config;
   },
 };
 

--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -1,4 +1,5 @@
 import type { StorybookConfig } from '@storybook/nextjs';
+import path from 'path';
 
 const config: StorybookConfig = {
   stories: ['../**/*.mdx', '../**/*.stories.@(js|jsx|mjs|ts|tsx)'],
@@ -12,6 +13,15 @@ const config: StorybookConfig = {
   framework: {
     name: '@storybook/nextjs',
     options: {},
+  },
+  webpackFinal: async (config) => {
+    if (config.resolve) {
+      config.resolve.alias = {
+        ...config.resolve.alias,
+        '@': path.resolve(__dirname, '..'),
+      };
+    }
+    return config;
   },
 };
 

--- a/.storybook/preview.ts
+++ b/.storybook/preview.ts
@@ -1,4 +1,5 @@
 import type { Preview } from '@storybook/react';
+import '../styled-system/styles.css';
 
 const preview: Preview = {
   parameters: {

--- a/components/atoms/button/button.stories.tsx
+++ b/components/atoms/button/button.stories.tsx
@@ -1,15 +1,51 @@
 import type { Meta, StoryObj } from '@storybook/react';
 
+import { css } from '@/styled-system/css';
+
 import { Button } from './button';
 
 const meta: Meta<typeof Button> = {
-  title: 'components/atoms/button',
+  title: 'Example/Button',
   component: Button,
+  tags: ['autodocs'],
+  decorators: [
+    (Story) => (
+      <div className={css({ margin: 10 })}>
+        <Story />
+      </div>
+    ),
+  ],
   argTypes: {
+    size: {
+      control: { type: 'select', options: ['small', 'medium', 'large'] },
+    },
     disabled: {
       control: 'boolean',
     },
-    onClick: { action: 'clicked' },
+    variant: {
+      control: { type: 'select', options: ['solid', 'outlined', 'text'] },
+    },
+    type: {
+      control: {
+        type: 'select',
+        options: ['primary', 'secondary', 'assistive'],
+      },
+    },
+    interaction: {
+      control: {
+        type: 'select',
+        options: ['normal', 'hovered', 'focused', 'pressed'],
+      },
+    },
+    label: {
+      control: 'text',
+    },
+    leftIconSrc: {
+      control: 'text',
+    },
+    rightIconSrc: {
+      control: 'text',
+    },
   },
 };
 
@@ -17,8 +53,26 @@ export default meta;
 
 type Story = StoryObj<typeof Button>;
 
-export const Basic: Story = {
+export const Default: Story = {
   args: {
-    children: 'Button',
+    label: 'Label',
+    size: 'large',
+    variant: 'solid',
+    type: 'primary',
+    interaction: 'normal',
+  },
+};
+
+export const outlined: Story = {
+  args: {
+    ...Default.args,
+    variant: 'outlined',
+  },
+};
+
+export const text: Story = {
+  args: {
+    ...Default.args,
+    variant: 'text',
   },
 };

--- a/components/atoms/button/button.tsx
+++ b/components/atoms/button/button.tsx
@@ -149,10 +149,9 @@ export const Button = ({
 
   const iconSize = size === 'large' ? 20 : size === 'medium' ? 18 : 16;
 
-  const iconWrapperStyles = css({
+  const iconWrapperStyles = flex({
     width: `${iconSize}px`,
     height: `${iconSize}px`,
-    display: 'flex',
     alignItems: 'center',
     justifyContent: 'center',
   });

--- a/components/atoms/button/button.tsx
+++ b/components/atoms/button/button.tsx
@@ -1,9 +1,185 @@
-import { ButtonHTMLAttributes, forwardRef } from 'react';
+import Image from 'next/image';
 
-interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {}
+import { css, cx } from '@/styled-system/css';
+import { flex } from '@/styled-system/patterns';
 
-export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
-  ({ ...props }, ref) => <button ref={ref} {...props} />,
-);
+import { ButtonProps } from './type';
 
-Button.displayName = 'Button';
+export const Button = ({
+  size = 'medium',
+  disabled = false,
+  leftIconSrc,
+  rightIconSrc,
+  label,
+  variant = 'solid',
+  type = 'primary',
+  interaction = 'normal',
+}: ButtonProps) => {
+  const baseStyles = flex({
+    alignItems: 'center',
+    justifyContent: leftIconSrc && rightIconSrc ? 'space-between' : 'center',
+    position: 'relative',
+    cursor: disabled ? 'not-allowed' : 'pointer',
+  });
+
+  const sizeStylesMap = new Map([
+    [
+      'large',
+      css({
+        height: '48px',
+        padding: '12px 28px',
+        borderRadius: '10px',
+        textStyle: 'body1.normal',
+        gap: '6px',
+      }),
+    ],
+    [
+      'medium',
+      css({
+        height: '40px',
+        padding: '9px 20px',
+        borderRadius: '8px',
+        textStyle: 'body2.normal',
+        gap: '5px',
+      }),
+    ],
+    [
+      'small',
+      css({
+        height: '32px',
+        padding: '7px 14px',
+        borderRadius: '6px',
+        textStyle: 'label2',
+        gap: '4px',
+      }),
+    ],
+  ]);
+
+  const variantStylesMap = new Map([
+    [
+      'solid',
+      css({
+        backgroundColor: disabled ? 'fill.disable' : 'blue.60',
+        border: 'none',
+      }),
+    ],
+    [
+      'outlined',
+      css({
+        backgroundColor: 'white',
+        border: '1px solid',
+        borderColor: disabled
+          ? 'line.normal'
+          : type === 'primary'
+            ? '#3B87F4'
+            : '#70737C38',
+      }),
+    ],
+    [
+      'text',
+      css({ backgroundColor: 'white', border: 'none', padding: '4px 0px' }),
+    ],
+  ]);
+
+  const typeStylesMap = new Map([
+    [
+      'primary',
+      css({
+        color: disabled
+          ? 'text.placeHolder'
+          : variant === 'solid'
+            ? 'white'
+            : 'blue.60',
+      }),
+    ],
+    [
+      'secondary',
+      css({
+        color: disabled
+          ? 'text.placeHolder'
+          : variant === 'solid'
+            ? 'white'
+            : '#3B87F4',
+      }),
+    ],
+    [
+      'assistive',
+      css({
+        color: disabled
+          ? 'text.placeHolder'
+          : variant === 'solid'
+            ? 'white'
+            : variant === 'outlined'
+              ? 'text.normal'
+              : 'text.alternative',
+      }),
+    ],
+  ]);
+
+  const interactionStylesMap = new Map([
+    ['hovered', css({ '&:hover::after': { opacity: 0.075 } })],
+    ['focused', css({ '&:focus::after': { opacity: 0.12 } })],
+    ['pressed', css({ '&:active::after': { opacity: 0.18 } })],
+  ]);
+
+  const buttonStyles = cx(
+    baseStyles,
+    sizeStylesMap.get(size),
+    variantStylesMap.get(variant),
+    typeStylesMap.get(type),
+    interactionStylesMap.get(interaction),
+    css({
+      fontWeight: '600',
+      '&::after': {
+        content: '""',
+        position: 'absolute',
+        top: 0,
+        left: 0,
+        width: '100%',
+        height: '100%',
+        borderRadius: 'inherit',
+        backgroundColor:
+          type === 'primary' && (variant === 'outlined' || variant === 'text')
+            ? 'blue.60'
+            : 'text.normal',
+        opacity: 0,
+      },
+    }),
+  );
+
+  const iconSize = size === 'large' ? 20 : size === 'medium' ? 18 : 16;
+
+  const iconWrapperStyles = css({
+    width: `${iconSize}px`,
+    height: `${iconSize}px`,
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+  });
+
+  return (
+    <button className={buttonStyles}>
+      {leftIconSrc && (
+        <div className={iconWrapperStyles}>
+          <Image
+            src={leftIconSrc}
+            alt="left icon"
+            width={iconSize}
+            height={iconSize}
+          />
+        </div>
+      )}
+      {label}
+      {rightIconSrc && (
+        <div className={iconWrapperStyles}>
+          <Image
+            src={rightIconSrc}
+            alt="right icon"
+            width={iconSize}
+            height={iconSize}
+          />
+        </div>
+      )}
+    </button>
+  );
+};

--- a/components/atoms/button/type.ts
+++ b/components/atoms/button/type.ts
@@ -1,0 +1,11 @@
+export interface ButtonProps {
+  size: 'large' | 'medium' | 'small';
+  disabled?: boolean;
+  label: string;
+  interaction: 'normal' | 'hovered' | 'focused' | 'pressed';
+  variant?: 'solid' | 'outlined' | 'text';
+  type?: 'primary' | 'secondary' | 'assistive';
+  leftIconSrc?: string;
+  rightIconSrc?: string;
+  onClick?: () => void;
+}

--- a/panda.config.ts
+++ b/panda.config.ts
@@ -22,6 +22,7 @@ export default defineConfig({
     './app/**/*.{js,jsx,ts,tsx}',
     './components/**/*.{js,jsx,ts,tsx}',
     './features/**/*.{js,jsx,ts,tsx}',
+    './stories/**/*.{js,jsx,ts,tsx}',
   ],
 
   // Files to exclude

--- a/postcss.config.cjs
+++ b/postcss.config.cjs
@@ -1,5 +1,3 @@
 module.exports = {
-  plugins: {
-    '@pandacss/dev/postcss': {},
-  },
+  plugins: [require('@pandacss/dev/postcss')()],
 };

--- a/postcss.config.cjs
+++ b/postcss.config.cjs
@@ -1,3 +1,5 @@
 module.exports = {
-  plugins: [require('@pandacss/dev/postcss')()],
+  plugins: {
+    '@pandacss/dev/postcss': {},
+  },
 };


### PR DESCRIPTION
<!-- 작성 예시 -->
<!-- # 어떤 문제가 발생했나요? -->
<!-- - 간략한 문제 설명 -->
<!-- - 문제 관련 링크 등등 -->
<!-- Ex) React v18 version update에 후 테스트에서 에러가 발생합니다.
  라이브러리의 버전이 호환이 되지않아서 문제입니다. -->

<!-- # 어떻게 해결했나요? -->
<!-- - 동작 방식 등 수정힌 코드에 대한 설명 -->
<!-- Ex) 라이브러리의 버전을 업데이트하고, v18을 사용할 수 있도록 dev dependency로 설치해주었습니다. -->

<!-- # 이미지 첨부 (Option) -->
<!-- - 이번 PR의 동작 이해를 돕는 GIF나 이미지 파일 첨부! -->
<!-- - 만약 없다면, NA 혹은 비워둡시다~ -->

<!-- # 유의할 점 (Option) -->
<!-- - 추가적으로 고민중이거나 조언을 구하고 싶은 내용, 어떤 것을 중점으로 리뷰를 해줬으면 좋겠는지 등등 작성 -->
<!-- - 만약 없다면, NA 혹은 비워둡시다~ -->

## 🤔 어떤 문제가 발생했나요?

- 공용 button 컴포넌트의 스타일링이 여러 분기라 코드가 복잡함
- storybook 설정 시 pandaCSS 적용이 되지 않음

## 🎉 어떻게 해결했나요?

- 기존에 tab 컴포넌트 때 팀원들이 코드 리뷰를 해주었던 것을 토대로 cx, Map을 사용해 유사한 형태로 리팩토링 진행
- pandaCSS 공식 문서대로 스토리북 적용을 진행 ([참고 링크](https://panda-css.com/docs/installation/storybook)) 

### 📷 이미지 첨부 (Option)

- 

### ⚠️ 유의할 점! (Option)

- 위에 참고한 공식 문서 2번째 스텝에서 
`pnpm install -D @pandacss/dev`
`pnpm panda init --postcss`를 하지 않으면 에러가 발생하는 것 같습니다!
- 현재 크로마틱 배포 설정 관련으로 에러가 발생하고 있어서 이 부분은 확인이 필요합니다! @hjy0951 🙇🏻

<!-- PR merge시 닫을 이슈가 있다면, 번호를 작성해주세요 -->
<!-- Ex) close #12 -->
