### PR TITLE
fix: useFormContext 관련 경고 해결

### DIFF
--- a/components/atoms/button/button.tsx
+++ b/components/atoms/button/button.tsx
@@ -14,6 +14,7 @@ export const Button = ({
   variant = 'solid',
   type = 'primary',
   interaction = 'normal',
+  className,
 }: ButtonProps) => {
   const baseStyles = flex({
     alignItems: 'center',
@@ -123,6 +124,7 @@ export const Button = ({
   ]);
 
   const buttonStyles = cx(
+    className,
     baseStyles,
     sizeStylesMap.get(size),
     variantStylesMap.get(variant),

--- a/components/atoms/button/button.tsx
+++ b/components/atoms/button/button.tsx
@@ -15,6 +15,7 @@ export const Button = ({
   type = 'primary',
   interaction = 'normal',
   className,
+  onClick
 }: ButtonProps) => {
   const baseStyles = flex({
     alignItems: 'center',
@@ -159,7 +160,7 @@ export const Button = ({
   });
 
   return (
-    <button className={buttonStyles}>
+    <button className={buttonStyles} onClick={onClick}>
       {leftIconSrc && (
         <div className={iconWrapperStyles}>
           <Image

--- a/components/atoms/button/type.ts
+++ b/components/atoms/button/type.ts
@@ -8,4 +8,5 @@ export interface ButtonProps {
   leftIconSrc?: string;
   rightIconSrc?: string;
   onClick?: () => void;
+  className?: string;
 }

--- a/components/molecules/tab/tab.tsx
+++ b/components/molecules/tab/tab.tsx
@@ -17,13 +17,13 @@ export const Tab = ({
   className = '',
 }: TabProps) => {
   const baseStyles = flex({
+    w: 'full',
     display: 'flex',
     alignItems: 'center',
     gap: '8px',
   });
 
   const primaryStyles = css({
-    width: '375px',
     height: '56px',
     backgroundColor: 'white',
     borderBottom: '1px solid',
@@ -31,7 +31,6 @@ export const Tab = ({
   });
 
   const secondaryStyles = css({
-    width: '335px',
     height: '44px',
     backgroundColor: 'background.gray',
     borderRadius: '12px',

--- a/features/record/components/molecules/pool-search-result-element.tsx
+++ b/features/record/components/molecules/pool-search-result-element.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import { useSetAtom } from 'jotai';
 import { useFormContext } from 'react-hook-form';
 


### PR DESCRIPTION
## 🤔 어떤 문제가 발생했나요?

- useFormContext를 사용하는 파일 내부에 'use client'를 선언해주지 않으면 경고가 발생합니다.

## 🎉 어떻게 해결했나요?

- 컴포넌트 상단에 'use client를 선언해주었습니다.

### 📷 이미지 첨부 (Option)

<img width="487" alt="image" src="https://github.com/user-attachments/assets/1830af88-5c09-41fe-8e66-e22a0587d42b">

### ⚠️ 유의할 점! (Option)

- NA
