### PR TITLE
chore: 공통 컴포넌트 일부 수정

### DIFF
--- a/components/atoms/button/button.tsx
+++ b/components/atoms/button/button.tsx
@@ -14,6 +14,7 @@ export const Button = ({
   variant = 'solid',
   type = 'primary',
   interaction = 'normal',
+  className,
 }: ButtonProps) => {
   const baseStyles = flex({
     alignItems: 'center',
@@ -123,6 +124,7 @@ export const Button = ({
   ]);
 
   const buttonStyles = cx(
+    className,
     baseStyles,
     sizeStylesMap.get(size),
     variantStylesMap.get(variant),

--- a/components/atoms/button/button.tsx
+++ b/components/atoms/button/button.tsx
@@ -15,6 +15,7 @@ export const Button = ({
   type = 'primary',
   interaction = 'normal',
   className,
+  onClick
 }: ButtonProps) => {
   const baseStyles = flex({
     alignItems: 'center',
@@ -159,7 +160,7 @@ export const Button = ({
   });
 
   return (
-    <button className={buttonStyles}>
+    <button className={buttonStyles} onClick={onClick}>
       {leftIconSrc && (
         <div className={iconWrapperStyles}>
           <Image

--- a/components/atoms/button/type.ts
+++ b/components/atoms/button/type.ts
@@ -8,4 +8,5 @@ export interface ButtonProps {
   leftIconSrc?: string;
   rightIconSrc?: string;
   onClick?: () => void;
+  className?: string;
 }

--- a/components/molecules/tab/tab.tsx
+++ b/components/molecules/tab/tab.tsx
@@ -17,13 +17,13 @@ export const Tab = ({
   className = '',
 }: TabProps) => {
   const baseStyles = flex({
+    w: 'full',
     display: 'flex',
     alignItems: 'center',
     gap: '8px',
   });
 
   const primaryStyles = css({
-    width: '375px',
     height: '56px',
     backgroundColor: 'white',
     borderBottom: '1px solid',
@@ -31,7 +31,6 @@ export const Tab = ({
   });
 
   const secondaryStyles = css({
-    width: '335px',
     height: '44px',
     backgroundColor: 'background.gray',
     borderRadius: '12px',


### PR DESCRIPTION
## 🤔 어떤 문제가 발생했나요?

- tab 컴포넌트의 type이 primary와 secondary일 경우, 화면을 꽉 채워주지 않았습니다.
- button 컴포넌트에 외부 스타일을 주입할 수 없었습니다.
- button 태그에 onClick 속성이 부여되지 않았습니다.

## 🎉 어떻게 해결했나요?

- tab 컴포넌트의 base style을 w:'full'로 한 뒤, 정적인 width는 외부에서 부여하는 로직으로 수정하였습니다. type="assistive" 인 경우에만 디폴트로 정적인 값을 유지하였습니다.
- button 컴포넌트의 props에 string 타입의 className prop을 추가하여 외부에서 스타일을 주입할 수 있도록 하였습니다.
- onClick prop을 button 태그에 주입하였습니다.

### 📷 이미지 첨부 (Option)

- 화면을 꽉 채워주지 않는 tab 컴포넌트

<img width="383" alt="image" src="https://github.com/user-attachments/assets/1200dba4-dbc8-464a-b9e8-7ae9082af98b">

### ⚠️ 유의할 점! (Option)

- NA
