### PR TITLE
fix: 소셜 로그인 페이지를 동적 임포트로 불러옵니다.

### DIFF
--- a/app/google/oauth/index.tsx
+++ b/app/google/oauth/index.tsx
@@ -1,7 +1,43 @@
-import dynamic from 'next/dynamic';
+'use client';
 
-const DynamicGoogleOAuthPage = dynamic(() => import('./page'), { ssr: false });
+import { useRouter, useSearchParams } from 'next/navigation';
+import { useEffect } from 'react';
 
-export default function GoogleOAuthPage() {
-  return <DynamicGoogleOAuthPage />;
-}
+const Page = () => {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+
+  useEffect(() => {
+    const GOOGLE_CODE = searchParams.get('code');
+
+    const postCode = async () => {
+      if (!GOOGLE_CODE) {
+        console.error('코드가 유효하지 않습니다.');
+        return;
+      }
+      try {
+        const response = await fetch(`/api/google/oauth?code=${GOOGLE_CODE}`, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify({ code: GOOGLE_CODE }),
+        });
+
+        if (response.status === 200) {
+          router.push('/');
+        }
+      } catch (error) {
+        console.error('Error:', error);
+      }
+    };
+
+    postCode().catch((error) => {
+      console.error('Error:', error);
+    });
+  }, [router, searchParams]);
+
+  return <div>구글로 로그인중입니다.</div>;
+};
+
+export default Page;

--- a/app/google/oauth/index.tsx
+++ b/app/google/oauth/index.tsx
@@ -1,0 +1,7 @@
+import dynamic from 'next/dynamic';
+
+const DynamicGoogleOAuthPage = dynamic(() => import('./page'), { ssr: false });
+
+export default function GoogleOAuthPage() {
+  return <DynamicGoogleOAuthPage />;
+}

--- a/app/google/oauth/page.tsx
+++ b/app/google/oauth/page.tsx
@@ -1,43 +1,7 @@
-'use client';
+import dynamic from 'next/dynamic';
 
-import { useRouter, useSearchParams } from 'next/navigation';
-import { useEffect } from 'react';
+const DynamicGoogleOAuthPage = dynamic(() => import('.'), { ssr: false });
 
-const Page = () => {
-  const router = useRouter();
-  const searchParams = useSearchParams();
-
-  useEffect(() => {
-    const GOOGLE_CODE = searchParams.get('code');
-
-    const postCode = async () => {
-      if (!GOOGLE_CODE) {
-        console.error('코드가 유효하지 않습니다.');
-        return;
-      }
-      try {
-        const response = await fetch(`/api/google/oauth?code=${GOOGLE_CODE}`, {
-          method: 'POST',
-          headers: {
-            'Content-Type': 'application/json',
-          },
-          body: JSON.stringify({ code: GOOGLE_CODE }),
-        });
-
-        if (response.status === 200) {
-          router.push('/');
-        }
-      } catch (error) {
-        console.error('Error:', error);
-      }
-    };
-
-    postCode().catch((error) => {
-      console.error('Error:', error);
-    });
-  }, [router, searchParams]);
-
-  return <div>구글로 로그인중입니다.</div>;
-};
-
-export default Page;
+export default function GoogleOAuthPage() {
+  return <DynamicGoogleOAuthPage />;
+}

--- a/app/kakao/oauth/index.tsx
+++ b/app/kakao/oauth/index.tsx
@@ -1,7 +1,43 @@
-import dynamic from 'next/dynamic';
+'use client';
 
-const DynamicKakaoOAuthPage = dynamic(() => import('./page'), { ssr: false });
+import { useRouter, useSearchParams } from 'next/navigation';
+import { useEffect } from 'react';
 
-export default function KakaoOAuthPage() {
-  return <DynamicKakaoOAuthPage />;
-}
+const Page = () => {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+
+  useEffect(() => {
+    const KAKAO_CODE = searchParams.get('code');
+
+    const postCode = async () => {
+      if (!KAKAO_CODE) {
+        console.error('코드가 유효하지 않습니다.');
+        return;
+      }
+      try {
+        const response = await fetch(`/api/kakao/oauth?code=${KAKAO_CODE}`, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify({ code: KAKAO_CODE }),
+        });
+
+        if (response.status === 200) {
+          router.push('/');
+        }
+      } catch (error) {
+        console.error('Error:', error);
+      }
+    };
+
+    postCode().catch((error) => {
+      console.error('Error:', error);
+    });
+  }, [router, searchParams]);
+
+  return <div>카카오톡으로 로그인중입니다.</div>;
+};
+
+export default Page;

--- a/app/kakao/oauth/index.tsx
+++ b/app/kakao/oauth/index.tsx
@@ -1,0 +1,7 @@
+import dynamic from 'next/dynamic';
+
+const DynamicKakaoOAuthPage = dynamic(() => import('./page'), { ssr: false });
+
+export default function KakaoOAuthPage() {
+  return <DynamicKakaoOAuthPage />;
+}

--- a/app/kakao/oauth/page.tsx
+++ b/app/kakao/oauth/page.tsx
@@ -1,43 +1,7 @@
-'use client';
+import dynamic from 'next/dynamic';
 
-import { useRouter, useSearchParams } from 'next/navigation';
-import { useEffect } from 'react';
+const DynamicKakaoOAuthPage = dynamic(() => import('.'), { ssr: false });
 
-const Page = () => {
-  const router = useRouter();
-  const searchParams = useSearchParams();
-
-  useEffect(() => {
-    const KAKAO_CODE = searchParams.get('code');
-
-    const postCode = async () => {
-      if (!KAKAO_CODE) {
-        console.error('코드가 유효하지 않습니다.');
-        return;
-      }
-      try {
-        const response = await fetch(`/api/kakao/oauth?code=${KAKAO_CODE}`, {
-          method: 'POST',
-          headers: {
-            'Content-Type': 'application/json',
-          },
-          body: JSON.stringify({ code: KAKAO_CODE }),
-        });
-
-        if (response.status === 200) {
-          router.push('/');
-        }
-      } catch (error) {
-        console.error('Error:', error);
-      }
-    };
-
-    postCode().catch((error) => {
-      console.error('Error:', error);
-    });
-  }, [router, searchParams]);
-
-  return <div>카카오톡으로 로그인중입니다.</div>;
-};
-
-export default Page;
+export default function KakaoOAuthPage() {
+  return <DynamicKakaoOAuthPage />;
+}


### PR DESCRIPTION
<!-- 작성 예시 -->
<!-- # 어떤 문제가 발생했나요? -->
<!-- - 간략한 문제 설명 -->
<!-- - 문제 관련 링크 등등 -->
<!-- Ex) React v18 version update에 후 테스트에서 에러가 발생합니다.
  라이브러리의 버전이 호환이 되지않아서 문제입니다. -->

<!-- # 어떻게 해결했나요? -->
<!-- - 동작 방식 등 수정힌 코드에 대한 설명 -->
<!-- Ex) 라이브러리의 버전을 업데이트하고, v18을 사용할 수 있도록 dev dependency로 설치해주었습니다. -->

<!-- # 이미지 첨부 (Option) -->
<!-- - 이번 PR의 동작 이해를 돕는 GIF나 이미지 파일 첨부! -->
<!-- - 만약 없다면, NA 혹은 비워둡시다~ -->

<!-- # 유의할 점 (Option) -->
<!-- - 추가적으로 고민중이거나 조언을 구하고 싶은 내용, 어떤 것을 중점으로 리뷰를 해줬으면 좋겠는지 등등 작성 -->
<!-- - 만약 없다면, NA 혹은 비워둡시다~ -->

## 🤔 어떤 문제가 발생했나요?

- 소셜 로그인(kakao, google)의 경우 컴포넌트가 아니라 페이지 자체가 클라이언트 사이드 렌더링이 되어야 하기 때문에 아래와 같은 에러가 발생했습니다.
`Error occurred prerendering page "/kakao/oauth". Read more: https://nextjs.org/docs/messages/prerender-error`

## 🎉 어떻게 해결했나요?

- 해당 페이지를 동적 임포트로 불러오고 SSR을 false로 설정했습니다. 
- 앱 라우터는 page.tsx를 디폴트로 보고 있기 때문에 동적 임포트로 불러오는 로그인 페이지를 page.tsx, 기존에 사용하던 로그인 페이지를 index.tsx로 파일명 변경했습니다.

### 📷 이미지 첨부 (Option)

-

### ⚠️ 유의할 점! (Option)

-

<!-- PR merge시 닫을 이슈가 있다면, 번호를 작성해주세요 -->
<!-- Ex) close #12 -->
