### PR TITLE
feat: middleware로 accessToken 재발급 및 리다이렉션

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -42,7 +42,7 @@ export async function middleware(request: NextRequest) {
     // TODO: refresh 사용하여 access 토큰 발급 + 헤더에 세팅
     if (isLoginPage) {
       // TODO: 로그인 페이지일 경우, '/'경로로 리다이렉트
-      return NextResponse.redirect(new URL('/login', request.url));
+      return NextResponse.redirect(new URL('/', request.url));
     }
     // TODO: 로그인 페이지가 아닌 경우, 토큰 발급만 진행
     return response;

--- a/middleware.ts
+++ b/middleware.ts
@@ -4,9 +4,8 @@ import { NextResponse } from 'next/server';
 import { NewTokenData } from './apis/refresh-token';
 
 export async function middleware(request: NextRequest) {
-  const cookies = request.cookies;
-  let accessToken = cookies.get('accessToken')?.value;
-  const refreshToken = cookies.get('refreshToken')?.value;
+  let accessToken = request.cookies.get('accessToken')?.value;
+  const refreshToken = request.cookies.get('refreshToken')?.value;
 
   const loginPageRegex = /^\/login$/;
   const isLoginPage = loginPageRegex.test(request.nextUrl.pathname);
@@ -16,7 +15,7 @@ export async function middleware(request: NextRequest) {
     return NextResponse.redirect(new URL('/login', request.url));
   }
 
-  // TODO: accessToken 재발급
+  // NOTE: accessToken 재발급
   if (refreshToken && !accessToken) {
     const responseData = await fetch(
       `${process.env.NEXT_PUBLIC_SERVER_URL}/login/refresh`,
@@ -30,21 +29,22 @@ export async function middleware(request: NextRequest) {
     );
 
     const data = (await responseData.json()) as NewTokenData;
-    accessToken = data.data.accessToken;
+    accessToken = `Bearer ${data.data.accessToken}`;
 
     const response = NextResponse.next();
-    response.cookies.set('accessToken', `Bearer ${accessToken}`, {
+    response.cookies.set('accessToken', accessToken, {
       maxAge: 3600,
       httpOnly: true,
       secure: true,
     });
 
-    // TODO: refresh 사용하여 access 토큰 발급 + 헤더에 세팅
+    response.headers.set('Authorization', accessToken);
+
+    // NOTE: 로그인 페이지일 경우, '/'경로로 리다이렉트
     if (isLoginPage) {
-      // TODO: 로그인 페이지일 경우, '/'경로로 리다이렉트
       return NextResponse.redirect(new URL('/', request.url));
     }
-    // TODO: 로그인 페이지가 아닌 경우, 토큰 발급만 진행
+    // NOTE: 로그인 페이지가 아닌 경우, 토큰 발급만 진행
     return response;
   }
 }


### PR DESCRIPTION
<!-- 작성 예시 -->
<!-- # 어떤 문제가 발생했나요? -->
<!-- - 간략한 문제 설명 -->
<!-- - 문제 관련 링크 등등 -->
<!-- Ex) React v18 version update에 후 테스트에서 에러가 발생합니다.
  라이브러리의 버전이 호환이 되지않아서 문제입니다. -->

<!-- # 어떻게 해결했나요? -->
<!-- - 동작 방식 등 수정힌 코드에 대한 설명 -->
<!-- Ex) 라이브러리의 버전을 업데이트하고, v18을 사용할 수 있도록 dev dependency로 설치해주었습니다. -->

<!-- # 이미지 첨부 (Option) -->
<!-- - 이번 PR의 동작 이해를 돕는 GIF나 이미지 파일 첨부! -->
<!-- - 만약 없다면, NA 혹은 비워둡시다~ -->

<!-- # 유의할 점 (Option) -->
<!-- - 추가적으로 고민중이거나 조언을 구하고 싶은 내용, 어떤 것을 중점으로 리뷰를 해줬으면 좋겠는지 등등 작성 -->
<!-- - 만약 없다면, NA 혹은 비워둡시다~ -->

## 🤔 어떤 문제가 발생했나요?

- 토큰이 없어도 페이지 리다이렉트가 발생하지 않음

## 🎉 어떻게 해결했나요?

- 토큰이 없을 시에 '/login'으로 리다이렉트 하는 로직을 추가합니다.
  - 로그인 페이지일 경우 '/' 경로로 이동합니다. 
- 토큰을 받으면 쿠키에 세팅 & 헤더에 설정합니다.


### 📷 이미지 첨부 (Option)

-

### ⚠️ 유의할 점! (Option)

-

<!-- PR merge시 닫을 이슈가 있다면, 번호를 작성해주세요 -->
<!-- Ex) close #12 -->
