### PR TITLE
fix: middleware에서 accessToken 설정 시 옵셔널 체이닝을 적용합니다.

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -29,7 +29,7 @@ export async function middleware(request: NextRequest) {
     );
 
     const data = (await responseData.json()) as NewTokenData;
-    accessToken = `Bearer ${data.data.accessToken}`;
+    accessToken = `Bearer ${data?.data?.accessToken}`;
 
     const response = NextResponse.next();
     response.cookies.set('accessToken', accessToken, {


### PR DESCRIPTION
<!-- 작성 예시 -->
<!-- # 어떤 문제가 발생했나요? -->
<!-- - 간략한 문제 설명 -->
<!-- - 문제 관련 링크 등등 -->
<!-- Ex) React v18 version update에 후 테스트에서 에러가 발생합니다.
  라이브러리의 버전이 호환이 되지않아서 문제입니다. -->

<!-- # 어떻게 해결했나요? -->
<!-- - 동작 방식 등 수정힌 코드에 대한 설명 -->
<!-- Ex) 라이브러리의 버전을 업데이트하고, v18을 사용할 수 있도록 dev dependency로 설치해주었습니다. -->

<!-- # 이미지 첨부 (Option) -->
<!-- - 이번 PR의 동작 이해를 돕는 GIF나 이미지 파일 첨부! -->
<!-- - 만약 없다면, NA 혹은 비워둡시다~ -->

<!-- # 유의할 점 (Option) -->
<!-- - 추가적으로 고민중이거나 조언을 구하고 싶은 내용, 어떤 것을 중점으로 리뷰를 해줬으면 좋겠는지 등등 작성 -->
<!-- - 만약 없다면, NA 혹은 비워둡시다~ -->

## 🤔 어떤 문제가 발생했나요?

- accessToken 세팅 시 undefined가 뜨는 경우가 있습니다.

## 🎉 어떻게 해결했나요?

- 옵셔널 체이닝을 설정했습니다.

### 📷 이미지 첨부 (Option)

-

### ⚠️ 유의할 점! (Option)

-

<!-- PR merge시 닫을 이슈가 있다면, 번호를 작성해주세요 -->
<!-- Ex) close #12 -->
