### PR TITLE
feat: record-detail 페이지 변경된 데이터 반영

### DIFF
--- a/app/record-detail/[id]/layout.tsx
+++ b/app/record-detail/[id]/layout.tsx
@@ -5,10 +5,14 @@ import { EditButton } from '@/features/record-detail/components';
 import { css } from '@/styled-system/css';
 import { flex } from '@/styled-system/patterns';
 
-const DetailLayout = ({ children }: { children: ReactNode }) => {
+type DetailLayout = {
+  children: ReactNode;
+  params: { id: string };
+};
+const DetailLayout = ({ children, params }: DetailLayout) => {
   return (
     <div>
-      <HeaderBar rightContent={<EditButton />}>
+      <HeaderBar rightContent={<EditButton memoryId={params.id} />}>
         <div className={header.textStyle}>지영의 수영 기록</div>
       </HeaderBar>
       <div className={childrenWrapperStyle}>{children}</div>

--- a/app/record-detail/[id]/page.tsx
+++ b/app/record-detail/[id]/page.tsx
@@ -16,7 +16,6 @@ export default async function RecordDetail({ params }: RecordDetail) {
     'GET',
   );
 
-  console.log(data);
   // TODO: add loading state
   if (!data) return null;
   return (

--- a/app/record-detail/[id]/page.tsx
+++ b/app/record-detail/[id]/page.tsx
@@ -16,6 +16,7 @@ export default async function RecordDetail({ params }: RecordDetail) {
     'GET',
   );
 
+  console.log(data);
   // TODO: add loading state
   if (!data) return null;
   return (

--- a/features/record-detail/components/edit-button.tsx
+++ b/features/record-detail/components/edit-button.tsx
@@ -1,17 +1,12 @@
-'use client';
+import Link from 'next/link';
 
 import { css } from '@/styled-system/css';
 
-export const EditButton = () => {
-  // TODO: edit button click event
-  const handleClickEditButton = () => {
-    console.log('edit');
-  };
-
+export const EditButton = ({ memoryId }: { memoryId: string }) => {
   return (
-    <button className={editButtonStyle} onClick={handleClickEditButton}>
+    <Link href={`/record?memoryId=${memoryId}`} className={editButtonStyle}>
       수정
-    </button>
+    </Link>
   );
 };
 

--- a/features/record-detail/sections/detail-description.tsx
+++ b/features/record-detail/sections/detail-description.tsx
@@ -11,11 +11,7 @@ export const DetailDescriptionSection = ({
   data: RecordDetailType;
 }) => {
   const { pool, duration, memoryDetail } = data;
-
   const { minute: durationMinute } = getFormatTime({ timeStr: duration });
-  const { hour: paceHour, minute: paceMinute } = getFormatTime({
-    timeStr: memoryDetail.pace,
-  });
 
   return (
     <section className={containerStyle}>
@@ -31,7 +27,7 @@ export const DetailDescriptionSection = ({
         />
         <SwimDescriptionItem
           title="⏱️평균 페이스"
-          value={`${paceHour}’${paceMinute}’’/100 m`}
+          value={`${memoryDetail.paceMinutes}’${memoryDetail.paceSeconds}’’/100 m`}
         />
         <SwimDescriptionItem
           title="🔥칼로리"

--- a/features/record-detail/sections/detail-preview.tsx
+++ b/features/record-detail/sections/detail-preview.tsx
@@ -108,6 +108,7 @@ export const DetailPreviewSection = ({ data }: { data: RecordDetailType }) => {
               }}
             />
           )}
+          <p className={goalText}>목표 {member.goal.toLocaleString()}m</p>
         </div>
 
         {/* preview description */}
@@ -150,11 +151,21 @@ const containerStyle = css({
 });
 
 const wavesStyle = flex({
-  height: '270px',
+  position: 'relative',
   width: 'full',
+  aspectRatio: '335 / 270',
   overflow: 'hidden',
   justifyContent: 'center',
   borderRadius: '3px',
+});
+
+const goalText = css({
+  position: 'absolute',
+  right: '8px',
+  bottom: '8px',
+  textStyle: 'label2.normal',
+  fontWeight: 'medium',
+  color: 'line.solid.neutral',
 });
 
 const graphArea = {

--- a/features/record-detail/sections/detail-preview.tsx
+++ b/features/record-detail/sections/detail-preview.tsx
@@ -12,7 +12,7 @@ import { DatePicker, SwimStatsItem, SwimToolItem } from '../components';
 import {
   type DetailStroke,
   type RecordDetailType,
-  type StrokeName,
+  type StrokeMapType,
 } from '../types';
 
 export const DetailPreviewSection = ({ data }: { data: RecordDetailType }) => {
@@ -26,6 +26,7 @@ export const DetailPreviewSection = ({ data }: { data: RecordDetailType }) => {
       width: containerRef.current.offsetWidth,
       height: containerRef.current.offsetHeight,
     });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [containerRef.current]);
 
   const toolArr = useMemo(() => {
@@ -60,11 +61,10 @@ export const DetailPreviewSection = ({ data }: { data: RecordDetailType }) => {
     type: 'string',
   });
 
-  type MapType = Record<StrokeName, DetailStroke>;
-  const strokesMap: MapType = strokes.reduce((acc, stroke) => {
+  const strokesMap: StrokeMapType = strokes.reduce((acc, stroke) => {
     acc[stroke.name] = stroke;
     return acc;
-  }, {} as MapType);
+  }, {} as StrokeMapType);
   const wavesData = swims.map(({ name, color }) => {
     const stroke: DetailStroke = strokesMap[name];
     return {
@@ -72,8 +72,6 @@ export const DetailPreviewSection = ({ data }: { data: RecordDetailType }) => {
       waveHeight: stroke.meter / member.goal,
     };
   });
-
-  console.log(wavesData);
 
   return (
     <section className={containerStyle}>

--- a/features/record-detail/sections/detail-preview.tsx
+++ b/features/record-detail/sections/detail-preview.tsx
@@ -2,8 +2,9 @@
 
 import { useEffect, useMemo, useRef, useState } from 'react';
 
-import { Waves } from '@/components/atoms';
+import { Image, Waves } from '@/components/atoms';
 import { swims } from '@/constants/visualization';
+import placeholderImage from '@/public/images/fallbackImage.png';
 import { css } from '@/styled-system/css';
 import { flex, grid } from '@/styled-system/patterns';
 import { getFormatTime } from '@/utils';
@@ -85,17 +86,29 @@ export const DetailPreviewSection = ({ data }: { data: RecordDetailType }) => {
         />
 
         {/* 파도 svg */}
-        {Boolean(strokes?.length) && (
-          <div className={wavesStyle} ref={containerRef}>
-            {containerRef.current && (
-              <Waves
-                waves={wavesData}
-                width={containerSize.width}
-                height={containerSize.height}
-              />
-            )}
-          </div>
-        )}
+        <div className={wavesStyle} ref={containerRef}>
+          {strokes?.length ? (
+            <>
+              {containerRef.current && (
+                <Waves
+                  waves={wavesData}
+                  width={containerSize.width}
+                  height={containerSize.height}
+                />
+              )}
+            </>
+          ) : (
+            <Image
+              src={placeholderImage}
+              alt="placeholder"
+              width={containerSize.width}
+              height={containerSize.height}
+              style={{
+                objectFit: 'cover',
+              }}
+            />
+          )}
+        </div>
 
         {/* preview description */}
         <div className={graphArea.textWrapper}>
@@ -136,9 +149,12 @@ const containerStyle = css({
   backgroundColor: 'white',
 });
 
-const wavesStyle = css({
+const wavesStyle = flex({
   height: '270px',
   width: 'full',
+  overflow: 'hidden',
+  justifyContent: 'center',
+  borderRadius: '3px',
 });
 
 const graphArea = {

--- a/features/record-detail/sections/detail-preview.tsx
+++ b/features/record-detail/sections/detail-preview.tsx
@@ -44,7 +44,7 @@ export const DetailPreviewSection = ({ data }: { data: RecordDetailType }) => {
         />
 
         {/* 파도 svg */}
-        <div>물결이 ~~</div>
+        <div className={wavesStyle}>물결이 ~~</div>
 
         {/* preview description */}
         <div className={graphArea.textWrapper}>
@@ -83,6 +83,11 @@ export const DetailPreviewSection = ({ data }: { data: RecordDetailType }) => {
 
 const containerStyle = css({
   backgroundColor: 'white',
+});
+
+const wavesStyle = css({
+  height: '270px',
+  width: 'full',
 });
 
 const graphArea = {

--- a/features/record-detail/types/index.ts
+++ b/features/record-detail/types/index.ts
@@ -10,6 +10,7 @@ export type DetailPool = {
   lane: number;
 };
 
+export type StrokeMapType = Record<StrokeName, DetailStroke>;
 export type StrokeName = '자유형' | '배영' | '접영' | '평영' | '킥판';
 export type DetailStroke = {
   strokeId: number;

--- a/features/record-detail/types/index.ts
+++ b/features/record-detail/types/index.ts
@@ -10,9 +10,10 @@ export type DetailPool = {
   lane: number;
 };
 
-export type DetailStrokes = {
+export type StrokeName = '자유형' | '배영' | '접영' | '평영' | '킥판';
+export type DetailStroke = {
   strokeId: number;
-  name: '자유형' | '배영' | '접영' | '평영' | '킥판';
+  name: StrokeName;
   laps: number;
   meter: number;
 };
@@ -30,7 +31,7 @@ export type RecordDetailType = {
   member: DetailMember;
   pool: DetailPool;
   memoryDetail: DetailMemoryDetail;
-  strokes: DetailStrokes[];
+  strokes: DetailStroke[];
   images: {
     imageName: string;
     url: string;

--- a/features/record-detail/types/index.ts
+++ b/features/record-detail/types/index.ts
@@ -20,7 +20,8 @@ export type DetailStrokes = {
 export type DetailMemoryDetail = {
   item: string;
   heartRate: number;
-  pace: string;
+  paceMinutes: string;
+  paceSeconds: string;
   kcal: number;
 };
 

--- a/utils/time.ts
+++ b/utils/time.ts
@@ -8,15 +8,14 @@ type GetTime = {
  *
  * @param {string} params.timeStr - 형식화할 시간 문자열
  * @param {'number' | 'string'} params.type - 반환 값 타입
- * @returns {Object} 시간 객체 (시간, 분, 초)
+ * @returns {Object} 시간 객체 (시간, 분)
  */
 export const getFormatTime = ({ timeStr, type = 'number' }: GetTime) => {
-  const [hour, minute, second] = timeStr.split(':');
+  const [hour, minute] = timeStr.split(':');
   const isTypeNumber = type === 'number';
 
   return {
     hour: isTypeNumber ? parseInt(hour, 10) : hour,
     minute: isTypeNumber ? parseInt(minute, 10) : minute,
-    second: isTypeNumber ? parseInt(second, 10) : second,
   };
 };


### PR DESCRIPTION
<!-- 작성 예시 -->
<!-- # 어떤 문제가 발생했나요? -->
<!-- - 간략한 문제 설명 -->
<!-- - 문제 관련 링크 등등 -->
<!-- Ex) React v18 version update에 후 테스트에서 에러가 발생합니다.
  라이브러리의 버전이 호환이 되지않아서 문제입니다. -->

<!-- # 어떻게 해결했나요? -->
<!-- - 동작 방식 등 수정힌 코드에 대한 설명 -->
<!-- Ex) 라이브러리의 버전을 업데이트하고, v18을 사용할 수 있도록 dev dependency로 설치해주었습니다. -->

<!-- # 이미지 첨부 (Option) -->
<!-- - 이번 PR의 동작 이해를 돕는 GIF나 이미지 파일 첨부! -->
<!-- - 만약 없다면, NA 혹은 비워둡시다~ -->

<!-- # 유의할 점 (Option) -->
<!-- - 추가적으로 고민중이거나 조언을 구하고 싶은 내용, 어떤 것을 중점으로 리뷰를 해줬으면 좋겠는지 등등 작성 -->
<!-- - 만약 없다면, NA 혹은 비워둡시다~ -->

## 🤔 어떤 문제가 발생했나요?

- 데이터 타입 변경
- 파도 이미지 렌더링 로직 누락
- 수정 버튼 클릭 시, 기록 페이지로의 이동 필요

## 🎉 어떻게 해결했나요?

- 변경된 데이터에 맞게 공통 함수와 사용하는 방법을 변경했습니다.
- 수영 데이터를 파싱하여 Waves component를 연동합니다.
- 수정 버튼 클릭 시, 해당 메모리 아이디를 쿼리 파라미터로 넣어 보내줍니다.

### 📷 이미지 첨부 (Option)

 <img width="346" alt="스크린샷 2024-08-03 오후 11 38 17" src="https://github.com/user-attachments/assets/609b2c9f-8574-4a72-be50-005809fd9750">

### ⚠️ 유의할 점! (Option)

-



<!-- PR merge시 닫을 이슈가 있다면, 번호를 작성해주세요 -->
<!-- Ex) close #12 -->
