### PR TITLE
feat: 달력 일자 클릭시 해당 날짜에 기록할 수 있도록 수정

### DIFF
--- a/features/main/calendar/atoms/calendar-item.tsx
+++ b/features/main/calendar/atoms/calendar-item.tsx
@@ -1,6 +1,8 @@
+import { useAtomValue } from 'jotai';
 import Link from 'next/link';
 import type { PropsWithChildren } from 'react';
 
+import { calendarDateAtom } from '@/store';
 import { css, cx } from '@/styled-system/css';
 import { flex } from '@/styled-system/patterns';
 
@@ -18,10 +20,16 @@ interface CalendarItemProps extends ItemLayoutProps {
 }
 
 export const CalendarItem = ({ date, isToday, memory }: CalendarItemProps) => {
+  const { year, month } = useAtomValue(calendarDateAtom);
+  const targetDate = `${year}-${month < 10 ? '0' : ''}${month}-${date < 10 ? '0' : ''}${date}`;
+
   if (!memory)
     return (
       <ItemLayout date={date} isToday={isToday}>
-        <Link href={`/record`} className={linkContainerStyles} />
+        <Link
+          href={`/record?date=${targetDate}`}
+          className={linkContainerStyles}
+        />
       </ItemLayout>
     );
 

--- a/features/record/components/organisms/form.tsx
+++ b/features/record/components/organisms/form.tsx
@@ -11,6 +11,7 @@ import { Divider } from '@/components/atoms/divider';
 import { TextField } from '@/components/molecules';
 import { css, cx } from '@/styled-system/css';
 import { flex } from '@/styled-system/patterns';
+import { formatDateToKorean, getToday } from '@/utils';
 
 import { useMemory } from '../../apis';
 import { RecordRequestProps } from '../../apis/dto';
@@ -36,13 +37,13 @@ import { TimeBottomSheet } from './time-bottom-sheet';
 //Todo: watch의 성능 이슈 고민
 export function Form() {
   const searchParams = useSearchParams();
+  const date = searchParams.get('date');
   const { data } = usePullMemory(Number(searchParams.get('memoryId')));
   const [formSubInfo, setFormSubInfo] = useAtom(formSubInfoState);
 
   const methods = useForm<RecordRequestProps>({
     defaultValues: {
-      // 달력 클릭하면 넘어오는 날짜를 default로 추후 수정
-      recordAt: '2024-05-23',
+      recordAt: date ? date : getToday(),
       startTime: '',
       endTime: '',
       lane: 25,
@@ -129,7 +130,7 @@ export function Form() {
           <TextField
             variant="select"
             isRequired
-            value="2024년 7월 25일"
+            value={formatDateToKorean(methods.getValues('recordAt'))}
             label="수영 날짜"
             wrapperClassName={css({ marginBottom: '24px' })}
           />

--- a/utils/date.ts
+++ b/utils/date.ts
@@ -40,3 +40,13 @@ export const isTodayDate = (dateStr: string) => {
     targetDate.getDate() === today.getDate()
   );
 };
+
+export const getToday = () => {
+  const today = new Date();
+  return `${today.getFullYear()}-${today.getMonth() + 1}-${today.getDate()}`;
+};
+
+export const formatDateToKorean = (dateStr: string, separator = '-') => {
+  const [year, month, date] = dateStr.split(separator);
+  return `${year}년 ${+month}월 ${+date}일`;
+};


### PR DESCRIPTION
<!-- 작성 예시 -->
<!-- # 어떤 문제가 발생했나요? -->
<!-- - 간략한 문제 설명 -->
<!-- - 문제 관련 링크 등등 -->
<!-- Ex) React v18 version update에 후 테스트에서 에러가 발생합니다.
  라이브러리의 버전이 호환이 되지않아서 문제입니다. -->

<!-- # 어떻게 해결했나요? -->
<!-- - 동작 방식 등 수정힌 코드에 대한 설명 -->
<!-- Ex) 라이브러리의 버전을 업데이트하고, v18을 사용할 수 있도록 dev dependency로 설치해주었습니다. -->

<!-- # 이미지 첨부 (Option) -->
<!-- - 이번 PR의 동작 이해를 돕는 GIF나 이미지 파일 첨부! -->
<!-- - 만약 없다면, NA 혹은 비워둡시다~ -->

<!-- # 유의할 점 (Option) -->
<!-- - 추가적으로 고민중이거나 조언을 구하고 싶은 내용, 어떤 것을 중점으로 리뷰를 해줬으면 좋겠는지 등등 작성 -->
<!-- - 만약 없다면, NA 혹은 비워둡시다~ -->

## 🤔 어떤 문제가 발생했나요?

- 달력에서 일자를 클릭해도 일자가 바뀌지 않았습니다

## 🎉 어떻게 해결했나요?

- query string을 이용해 날짜를 전달하여 해당 날짜에 수영 기록을 추가할 수 있도록 수정하였습니다.

### 📷 이미지 첨부 (Option)

<img width="608" alt="스크린샷 2024-08-05 오후 3 59 49" src="https://github.com/user-attachments/assets/779d29a9-896d-46ca-98a7-76bd742250f8">

### ⚠️ 유의할 점! (Option)

-

<!-- PR merge시 닫을 이슈가 있다면, 번호를 작성해주세요 -->
<!-- Ex) close #12 -->
