### PR TITLE
fix: item 타입에 맞게 item 유무 확인 로직 수정

### DIFF
--- a/features/record-detail/sections/detail-preview.tsx
+++ b/features/record-detail/sections/detail-preview.tsx
@@ -151,7 +151,7 @@ export const DetailPreviewSection = ({ data }: { data: RecordDetailType }) => {
       )}
 
       {/* NOTE: 수영 장비 영역 */}
-      {Boolean(memoryDetail?.item.length) && (
+      {Boolean(memoryDetail?.item) && (
         <div className={toolsContainer}>
           {memoryDetail?.item
             .split(',')


### PR DESCRIPTION
## 🤔 어떤 문제가 발생했나요?

- item이 string 타입이기 때문에 item.length로 item의 유무를 확인하는 로직에 에러가 발생하였습니다.

## 🎉 어떻게 해결했나요?

- .length를 제거하여 해결했습니다.

### 📷 이미지 첨부 (Option)

- NA

### ⚠️ 유의할 점! (Option)

- NA
