### PR TITLE
fix: record-detail 누락된 예외처리 추가 및 RecordMark component 수정

### DIFF
--- a/components/molecules/index.ts
+++ b/components/molecules/index.ts
@@ -2,6 +2,7 @@ export * from './bottom-sheet';
 export * from './dialog';
 export * from './header-bar';
 export * from './page-modal';
+export * from './record-mark';
 export * from './search-bar';
 export * from './tab';
 export * from './text-area';

--- a/components/molecules/record-mark/record-mark.tsx
+++ b/components/molecules/record-mark/record-mark.tsx
@@ -1,9 +1,11 @@
+'use client';
+
 import { useEffect, useRef, useState } from 'react';
 
 import { Waves } from '@/components/atoms';
 import { SwimmerIcon } from '@/components/atoms/icons/swimmer-icon';
 import { StrokeInfo } from '@/features/main/time-line';
-import { css, cx } from '@/styled-system/css';
+import { css, cva, cx } from '@/styled-system/css';
 import { flex } from '@/styled-system/patterns';
 import { createGradient, getSwimColor } from '@/utils';
 
@@ -12,6 +14,7 @@ interface RecordMarkProps {
   isAchieved?: boolean;
   totalDistance?: number;
   strokes?: Array<StrokeInfo>;
+  renderType?: 'calendar' | 'detail';
 }
 
 // TODO: 로그인 이후 저장된 유저의 목표 거리로 수정 필요
@@ -22,6 +25,7 @@ export const RecordMark = ({
   isAchieved,
   totalDistance,
   strokes,
+  renderType = 'calendar',
 }: RecordMarkProps) => {
   const ref = useRef<HTMLDivElement | null>(null);
   const [contentSize, setContentSize] = useState<{
@@ -51,7 +55,7 @@ export const RecordMark = ({
   if (type === 'NORMAL')
     return (
       <div ref={ref} className={wrapperStyles}>
-        <div className={cx(layoutStyles, normalStyles)}>
+        <div className={cx(layoutStyles({ renderType }), normalStyles)}>
           <SwimmerIcon />
         </div>
       </div>
@@ -60,9 +64,11 @@ export const RecordMark = ({
     return (
       <div ref={ref} className={wrapperStyles}>
         {isAchieved ? (
-          <div className={cx(layoutStyles, singleAchievedStyles)} />
+          <div
+            className={cx(layoutStyles({ renderType }), singleAchievedStyles)}
+          />
         ) : (
-          <div className={layoutStyles}>
+          <div className={layoutStyles({ renderType })}>
             {totalDistance && (
               <Waves
                 width={contentSize.width}
@@ -87,10 +93,10 @@ export const RecordMark = ({
       {isAchieved ? (
         <div
           style={{ backgroundImage: `linear-gradient(0deg, ${gradientProps})` }}
-          className={layoutStyles}
+          className={layoutStyles({ renderType })}
         />
       ) : (
-        <div className={layoutStyles}>
+        <div className={layoutStyles({ renderType })}>
           {totalDistance && (
             <Waves
               width={contentSize.width}
@@ -111,13 +117,27 @@ const wrapperStyles = flex({
   justifyContent: 'center',
 });
 
-const layoutStyles = flex({
-  width: '95%',
-  aspectRatio: 'auto 3/4',
-  alignItems: 'center',
-  justifyContent: 'center',
-  rounded: '2px',
-  overflow: 'hidden',
+const layoutStyles = cva({
+  base: {
+    display: 'flex',
+    aspectRatio: 'auto 3/4',
+    alignItems: 'center',
+    justifyContent: 'center',
+    rounded: '2px',
+    overflow: 'hidden',
+  },
+  variants: {
+    renderType: {
+      calendar: {
+        width: '95%',
+        aspectRatio: 'auto 3/4',
+      },
+      detail: {
+        width: '100%',
+        aspectRatio: 'auto 335 / 270',
+      },
+    },
+  },
 });
 
 const normalStyles = css({ backgroundColor: 'blue.90' });

--- a/features/record-detail/sections/detail-description.tsx
+++ b/features/record-detail/sections/detail-description.tsx
@@ -12,6 +12,16 @@ export const DetailDescriptionSection = ({
 }) => {
   const { pool, duration, memoryDetail } = data;
 
+  // NOTE: data type이 number이므로 0일 경우 예외처리를 위해 Boolean 사용
+  const heartRate = memoryDetail?.heartRate
+    ? `${memoryDetail?.heartRate} bpm`
+    : undefined;
+  const pace =
+    Boolean(memoryDetail?.paceMinutes) && Boolean(memoryDetail?.paceSeconds)
+      ? `${memoryDetail?.paceMinutes}’${memoryDetail?.paceSeconds}’’/100 m`
+      : undefined;
+  const kcal = memoryDetail?.kcal ? `${memoryDetail?.kcal}kcal` : undefined;
+
   return (
     <section className={containerStyle}>
       <div className={infoWrapperStyle}>
@@ -23,18 +33,9 @@ export const DetailDescriptionSection = ({
       </div>
 
       <div className={detailWrapperStyle}>
-        <SwimDescriptionItem
-          title="♥️심박수"
-          value={`${memoryDetail?.heartRate} bpm`}
-        />
-        <SwimDescriptionItem
-          title="⏱️평균 페이스"
-          value={`${memoryDetail?.paceMinutes}’${memoryDetail?.paceSeconds}’’/100 m`}
-        />
-        <SwimDescriptionItem
-          title="🔥칼로리"
-          value={`${memoryDetail?.kcal}kcal`}
-        />
+        <SwimDescriptionItem title="♥️심박수" value={heartRate} />
+        <SwimDescriptionItem title="⏱️평균 페이스" value={pace} />
+        <SwimDescriptionItem title="🔥칼로리" value={kcal} />
       </div>
     </section>
   );

--- a/features/record-detail/sections/detail-description.tsx
+++ b/features/record-detail/sections/detail-description.tsx
@@ -17,9 +17,10 @@ export const DetailDescriptionSection = ({
   const heartRate = Boolean(memoryDetail?.heartRate)
     ? `${memoryDetail?.heartRate} bpm`
     : undefined;
-  const pace = Boolean(memoryDetail?.paceMinutes)
-    ? `${memoryDetail?.paceMinutes}’${memoryDetail?.paceSeconds}’’/100 m`
-    : undefined;
+  const pace =
+    Boolean(memoryDetail?.paceMinutes) || Boolean(memoryDetail?.paceSeconds)
+      ? `${memoryDetail?.paceMinutes}’${memoryDetail?.paceSeconds}’’/100 m`
+      : undefined;
   const kcal = Boolean(memoryDetail?.kcal)
     ? `${memoryDetail?.kcal}kcal`
     : undefined;

--- a/features/record-detail/sections/detail-description.tsx
+++ b/features/record-detail/sections/detail-description.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-extra-boolean-cast */
 import { css } from '@/styled-system/css';
 import { grid } from '@/styled-system/patterns';
 import { getFormatTime } from '@/utils';
@@ -13,14 +14,15 @@ export const DetailDescriptionSection = ({
   const { pool, duration, memoryDetail } = data;
 
   // NOTE: data type이 number이므로 0일 경우 예외처리를 위해 Boolean 사용
-  const heartRate = memoryDetail?.heartRate
+  const heartRate = Boolean(memoryDetail?.heartRate)
     ? `${memoryDetail?.heartRate} bpm`
     : undefined;
-  const pace =
-    Boolean(memoryDetail?.paceMinutes) && Boolean(memoryDetail?.paceSeconds)
-      ? `${memoryDetail?.paceMinutes}’${memoryDetail?.paceSeconds}’’/100 m`
-      : undefined;
-  const kcal = memoryDetail?.kcal ? `${memoryDetail?.kcal}kcal` : undefined;
+  const pace = Boolean(memoryDetail?.paceMinutes)
+    ? `${memoryDetail?.paceMinutes}’${memoryDetail?.paceSeconds}’’/100 m`
+    : undefined;
+  const kcal = Boolean(memoryDetail?.kcal)
+    ? `${memoryDetail?.kcal}kcal`
+    : undefined;
 
   return (
     <section className={containerStyle}>

--- a/features/record-detail/sections/detail-preview.tsx
+++ b/features/record-detail/sections/detail-preview.tsx
@@ -1,7 +1,5 @@
 'use client';
 
-import { useEffect, useRef, useState } from 'react';
-
 import { Image } from '@/components/atoms';
 import { RecordMark } from '@/components/molecules';
 import placeholderImage from '@/public/images/fallbackImage.png';
@@ -13,19 +11,6 @@ import { DatePicker, SwimStatsItem, SwimToolItem } from '../components';
 import { type RecordDetailType } from '../types';
 
 export const DetailPreviewSection = ({ data }: { data: RecordDetailType }) => {
-  const containerRef = useRef<HTMLDivElement>(null);
-  const [containerSize, setContainerSize] = useState({ width: 0, height: 0 });
-
-  useEffect(() => {
-    if (!containerRef.current) return;
-
-    setContainerSize({
-      width: containerRef.current.offsetWidth,
-      height: containerRef.current.offsetHeight,
-    });
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [containerRef.current]);
-
   const handleClickPreviousDate = () => {
     console.log('prev');
   };
@@ -68,27 +53,22 @@ export const DetailPreviewSection = ({ data }: { data: RecordDetailType }) => {
         />
 
         {/* 파도 svg */}
-        <div className={wavesStyle} ref={containerRef}>
+        <div className={wavesStyle}>
           {strokes?.length ? (
-            <>
-              {containerRef.current && (
-                <RecordMark
-                  isAchieved={Boolean(
-                    member?.goal && totalMeter && totalMeter > member?.goal,
-                  )}
-                  strokes={strokes}
-                  totalDistance={totalMeter}
-                  type={type}
-                  renderType="detail"
-                />
+            <RecordMark
+              isAchieved={Boolean(
+                member?.goal && totalMeter && totalMeter > member?.goal,
               )}
-            </>
+              strokes={strokes}
+              totalDistance={totalMeter}
+              type={type}
+              renderType="detail"
+            />
           ) : (
             <Image
               src={placeholderImage}
               alt="placeholder"
-              width={containerSize.width}
-              height={containerSize.height}
+              fill
               style={{
                 objectFit: 'cover',
               }}

--- a/features/record-detail/sections/detail-preview.tsx
+++ b/features/record-detail/sections/detail-preview.tsx
@@ -2,7 +2,8 @@
 
 import { useEffect, useMemo, useRef, useState } from 'react';
 
-import { Image, Waves } from '@/components/atoms';
+import { Image } from '@/components/atoms';
+import { RecordMark } from '@/components/molecules';
 import { swims } from '@/constants/visualization';
 import placeholderImage from '@/public/images/fallbackImage.png';
 import { css } from '@/styled-system/css';
@@ -48,6 +49,7 @@ export const DetailPreviewSection = ({ data }: { data: RecordDetailType }) => {
     recordAt,
     member,
     memoryDetail,
+    type,
   } = data;
 
   const { hour: startHour, minute: startMinute } = getFormatTime({
@@ -94,10 +96,14 @@ export const DetailPreviewSection = ({ data }: { data: RecordDetailType }) => {
           {wavesArr ? (
             <>
               {containerRef.current && (
-                <Waves
-                  waves={wavesArr}
-                  width={containerSize.width}
-                  height={containerSize.height}
+                <RecordMark
+                  isAchieved={Boolean(
+                    member?.goal && totalMeter && totalMeter > member?.goal,
+                  )}
+                  strokes={strokes}
+                  totalDistance={totalMeter}
+                  type={type}
+                  renderType="detail"
                 />
               )}
             </>

--- a/features/record-detail/sections/detail-preview.tsx
+++ b/features/record-detail/sections/detail-preview.tsx
@@ -1,21 +1,16 @@
 'use client';
 
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 
 import { Image } from '@/components/atoms';
 import { RecordMark } from '@/components/molecules';
-import { swims } from '@/constants/visualization';
 import placeholderImage from '@/public/images/fallbackImage.png';
 import { css } from '@/styled-system/css';
 import { flex, grid } from '@/styled-system/patterns';
 import { getFormatTime } from '@/utils';
 
 import { DatePicker, SwimStatsItem, SwimToolItem } from '../components';
-import {
-  type DetailStroke,
-  type RecordDetailType,
-  type StrokeMapType,
-} from '../types';
+import { type RecordDetailType } from '../types';
 
 export const DetailPreviewSection = ({ data }: { data: RecordDetailType }) => {
   const containerRef = useRef<HTMLDivElement>(null);
@@ -61,25 +56,6 @@ export const DetailPreviewSection = ({ data }: { data: RecordDetailType }) => {
     type: 'string',
   });
 
-  const wavesArr = useMemo(() => {
-    if (!strokes.length || !member?.goal) {
-      return null;
-    }
-
-    const strokesMap = strokes.reduce((acc, stroke) => {
-      acc[stroke.name] = stroke;
-      return acc;
-    }, {} as StrokeMapType);
-
-    return swims.map(({ name, color }) => {
-      const stroke: DetailStroke = strokesMap[name];
-      return {
-        color,
-        waveHeight: stroke?.meter / member.goal ?? 0,
-      };
-    });
-  }, [member?.goal, strokes]);
-
   return (
     <section className={containerStyle}>
       {/* NOTE: 상단 그래프 영역 */}
@@ -93,7 +69,7 @@ export const DetailPreviewSection = ({ data }: { data: RecordDetailType }) => {
 
         {/* 파도 svg */}
         <div className={wavesStyle} ref={containerRef}>
-          {wavesArr ? (
+          {strokes?.length ? (
             <>
               {containerRef.current && (
                 <RecordMark


### PR DESCRIPTION
<!-- 작성 예시 -->
<!-- # 어떤 문제가 발생했나요? -->
<!-- - 간략한 문제 설명 -->
<!-- - 문제 관련 링크 등등 -->
<!-- Ex) React v18 version update에 후 테스트에서 에러가 발생합니다.
  라이브러리의 버전이 호환이 되지않아서 문제입니다. -->

<!-- # 어떻게 해결했나요? -->
<!-- - 동작 방식 등 수정힌 코드에 대한 설명 -->
<!-- Ex) 라이브러리의 버전을 업데이트하고, v18을 사용할 수 있도록 dev dependency로 설치해주었습니다. -->

<!-- # 이미지 첨부 (Option) -->
<!-- - 이번 PR의 동작 이해를 돕는 GIF나 이미지 파일 첨부! -->
<!-- - 만약 없다면, NA 혹은 비워둡시다~ -->

<!-- # 유의할 점 (Option) -->
<!-- - 추가적으로 고민중이거나 조언을 구하고 싶은 내용, 어떤 것을 중점으로 리뷰를 해줬으면 좋겠는지 등등 작성 -->
<!-- - 만약 없다면, NA 혹은 비워둡시다~ -->

## 🤔 어떤 문제가 발생했나요?

- 기록 상세 페이지에서 optional data 예외처리가 누락되었습니다.
- RecordMark component의 UI가 detail에서는 달라야 합니다.

## 🎉 어떻게 해결했나요?

- 기록 상세 페이지에 예외처리를 추가합니다
- RecordMark component에 renderType props를 추가하고 스타일을 분기처리합니다.

### 📷 이미지 첨부 (Option)

1. 기록상세
<img width="354" alt="스크린샷 2024-08-08 오전 12 54 27" src="https://github.com/user-attachments/assets/56dbb33a-4a92-4d64-bff7-16d8fff1d844">

2. 캘린더 화면
<img width="357" alt="스크린샷 2024-08-08 오전 12 54 57" src="https://github.com/user-attachments/assets/6e4b8e5c-abe5-4d6e-bf85-97df29d8e03b">


### ⚠️ 유의할 점! (Option)

-

<!-- PR merge시 닫을 이슈가 있다면, 번호를 작성해주세요 -->
<!-- Ex) close #12 -->
