### PR TITLE
fix: page-modal과 기록 성공 페이지 확인 버튼에 max-width 속성 적용

### DIFF
--- a/app/record/success/page.tsx
+++ b/app/record/success/page.tsx
@@ -64,5 +64,6 @@ const buttonStyles = css({
   position: 'fixed',
   bottom: '36px',
   width: 'full',
+  maxWidth: 'maxWidth',
   padding: '0 20px',
 });

--- a/components/molecules/page-modal/page-modal.tsx
+++ b/components/molecules/page-modal/page-modal.tsx
@@ -41,8 +41,8 @@ PageModal.displayName = 'PageModal';
 const layoutStyles = css({
   position: 'fixed',
   bottom: 0,
-  left: 0,
   width: '100vw',
+  maxWidth: 'maxWidth',
   height: '100vh',
   backgroundColor: 'white',
   zIndex: 1000,


### PR DESCRIPTION
## 🤔 어떤 문제가 발생했나요?

- page-modal과 기록 성공 페이지 확인 버튼에 max-width 속성이 적용되지 않았습니다.

## 🎉 어떻게 해결했나요?

- page-modal과 기록 성공 페이지 확인 버튼에 max-width를 적용하였습니다.

### 📷 이미지 첨부 (Option)

<img width="533" alt="image" src="https://github.com/user-attachments/assets/1e25e511-8d4e-444d-a855-8e32ac577a4b">

<img width="615" alt="image" src="https://github.com/user-attachments/assets/2d4d1c1f-4344-4a00-a500-01c6cd49cb44">

### ⚠️ 유의할 점! (Option)

- NA
