### PR TITLE
fix: time-picker가 바텀시트보다 먼저 올라오는 현상 수정

### DIFF
--- a/features/record/components/organisms/time-bottom-sheet.tsx
+++ b/features/record/components/organisms/time-bottom-sheet.tsx
@@ -1,15 +1,14 @@
 'use client';
 
-import '../../styles/time-picker.css';
-
 import { ConfigProvider, TimePicker } from 'antd';
 import dayjs from 'dayjs';
 import { useAtom } from 'jotai';
+import { useEffect, useState } from 'react';
 import { useFormContext } from 'react-hook-form';
 
 import { Button } from '@/components/atoms';
 import { BottomSheet } from '@/components/molecules';
-import { css, cx } from '@/styled-system/css';
+import { css } from '@/styled-system/css';
 import { flex } from '@/styled-system/patterns';
 
 import useGetBrowserWidth from '../../hooks/use-get-browser-width';
@@ -20,6 +19,7 @@ export function TimeBottomSheet() {
   const [timeBottmSheetState, setTimeBottmSheetState] =
     useAtom(timeBottomSheetState);
   const width = useGetBrowserWidth();
+  const [showTimePicker, setShowTimePicker] = useState(false);
 
   const handleTimeChange = (date: dayjs.Dayjs) => {
     setTimeBottmSheetState((prev) => ({ ...prev, time: date.format('HH:mm') }));
@@ -31,6 +31,14 @@ export function TimeBottomSheet() {
       setValue('endTime', timeBottmSheetState.time);
     setTimeBottmSheetState((prev) => ({ ...prev, isOpen: false }));
   };
+
+  useEffect(() => {
+    if (timeBottmSheetState.isOpen) {
+      setTimeout(() => {
+        setShowTimePicker(true);
+      }, 150);
+    } else setShowTimePicker(false);
+  }, [timeBottmSheetState.isOpen]);
 
   return (
     <BottomSheet
@@ -63,19 +71,26 @@ export function TimeBottomSheet() {
             placeholder="시간 설정"
             format="HH:mm"
             use12Hours
-            suffixIcon={<span></span>}
-            panelRender={(originPanel) => (
-              <div
-                className={css({
-                  position: 'fixed',
-                  bottom: '82px',
-                  textStyle: 'heading3',
-                  fontWeight: 400,
-                })}
-              >
-                {originPanel}
-              </div>
-            )}
+            suffixIcon={null}
+            popupClassName={css({
+              opacity: showTimePicker ? 1 : 0,
+              transition: 'opacity 0.3s ease-in-out',
+            })}
+            panelRender={(originPanel) =>
+              showTimePicker ? (
+                <div
+                  className={css({
+                    position: 'fixed',
+                    bottom: '82px',
+                    left: 0,
+                    textStyle: 'heading3',
+                    fontWeight: 400,
+                  })}
+                >
+                  {originPanel}
+                </div>
+              ) : null
+            }
             open={timeBottmSheetState.isOpen}
             showNow={false}
             inputMode="none"
@@ -85,7 +100,10 @@ export function TimeBottomSheet() {
             inputReadOnly
             onPickerValueChange={handleTimeChange}
             variant="borderless"
-            className={cx(css({ width: '100%' }), 'custom-picker')}
+            className={css({
+              width: '100%',
+              '& input': { visibility: 'hidden' },
+            })}
           />
         </div>
       </ConfigProvider>
@@ -104,7 +122,6 @@ export function TimeBottomSheet() {
 
 const layout = {
   bottomSheet: flex({
-    position: 'relative',
     direction: 'column',
     alignItems: 'center',
     width: '100%',

--- a/features/record/components/organisms/time-bottom-sheet.tsx
+++ b/features/record/components/organisms/time-bottom-sheet.tsx
@@ -3,7 +3,6 @@
 import { ConfigProvider, TimePicker } from 'antd';
 import dayjs from 'dayjs';
 import { useAtom } from 'jotai';
-import { useEffect, useState } from 'react';
 import { useFormContext } from 'react-hook-form';
 
 import { Button } from '@/components/atoms';
@@ -11,19 +10,21 @@ import { BottomSheet } from '@/components/molecules';
 import { css } from '@/styled-system/css';
 import { flex } from '@/styled-system/patterns';
 
-import useGetBrowserWidth from '../../hooks/use-get-browser-width';
+import { useTimeBottomSheet } from '../../hooks';
 import { timeBottomSheetState } from '../../store';
 
 export function TimeBottomSheet() {
   const { setValue } = useFormContext();
   const [timeBottmSheetState, setTimeBottmSheetState] =
     useAtom(timeBottomSheetState);
-  const width = useGetBrowserWidth();
-  const [showTimePicker, setShowTimePicker] = useState(false);
+  const { width, showTimePicker } = useTimeBottomSheet(
+    timeBottmSheetState.isOpen,
+  );
 
   const handleTimeChange = (date: dayjs.Dayjs) => {
     setTimeBottmSheetState((prev) => ({ ...prev, time: date.format('HH:mm') }));
   };
+
   const handleDoneButtonClick = () => {
     if (timeBottmSheetState.variant === 'start')
       setValue('startTime', timeBottmSheetState.time);
@@ -31,14 +32,6 @@ export function TimeBottomSheet() {
       setValue('endTime', timeBottmSheetState.time);
     setTimeBottmSheetState((prev) => ({ ...prev, isOpen: false }));
   };
-
-  useEffect(() => {
-    if (timeBottmSheetState.isOpen) {
-      setTimeout(() => {
-        setShowTimePicker(true);
-      }, 150);
-    } else setShowTimePicker(false);
-  }, [timeBottmSheetState.isOpen]);
 
   return (
     <BottomSheet
@@ -66,7 +59,7 @@ export function TimeBottomSheet() {
           },
         }}
       >
-        <div className={layout.bottomSheet}>
+        <div className={layoutStyles.bottomSheet}>
           <TimePicker
             placeholder="시간 설정"
             format="HH:mm"
@@ -78,17 +71,7 @@ export function TimeBottomSheet() {
             })}
             panelRender={(originPanel) =>
               showTimePicker ? (
-                <div
-                  className={css({
-                    position: 'fixed',
-                    bottom: '82px',
-                    left: 0,
-                    textStyle: 'heading3',
-                    fontWeight: 400,
-                  })}
-                >
-                  {originPanel}
-                </div>
+                <div className={panelStyles}>{originPanel}</div>
               ) : null
             }
             open={timeBottmSheetState.isOpen}
@@ -107,7 +90,7 @@ export function TimeBottomSheet() {
           />
         </div>
       </ConfigProvider>
-      <div className={layout.button}>
+      <div className={layoutStyles.button}>
         <Button
           size="large"
           label="완료"
@@ -120,7 +103,7 @@ export function TimeBottomSheet() {
   );
 }
 
-const layout = {
+const layoutStyles = {
   bottomSheet: flex({
     direction: 'column',
     alignItems: 'center',
@@ -136,3 +119,11 @@ const layout = {
     padding: '0 20px',
   }),
 };
+
+const panelStyles = css({
+  position: 'fixed',
+  bottom: '82px',
+  left: 0,
+  textStyle: 'heading3',
+  fontWeight: 400,
+});

--- a/features/record/hooks/index.ts
+++ b/features/record/hooks/index.ts
@@ -2,3 +2,4 @@ export * from './use-distance-page-modal';
 export * from './use-get-browser-width';
 export * from './use-pool-search-page-modal';
 export * from './use-sub-info-text-fields';
+export * from './use-time-bottom-sheet';

--- a/features/record/hooks/use-time-bottom-sheet.tsx
+++ b/features/record/hooks/use-time-bottom-sheet.tsx
@@ -9,11 +9,21 @@ export function useTimeBottomSheet(isBottomSheetOpen: boolean) {
   const width = useGetBrowserWidth();
 
   useEffect(() => {
+    let timer: number | undefined;
+
     if (isBottomSheetOpen) {
-      setTimeout(() => {
+      timer = window.setTimeout(() => {
         setShowTimePicker(true);
       }, 150);
-    } else setShowTimePicker(false);
+    } else {
+      setShowTimePicker(false);
+    }
+
+    return () => {
+      if (timer !== undefined) {
+        clearTimeout(timer);
+      }
+    };
   }, [isBottomSheetOpen]);
 
   return { width, showTimePicker };

--- a/features/record/hooks/use-time-bottom-sheet.tsx
+++ b/features/record/hooks/use-time-bottom-sheet.tsx
@@ -1,0 +1,20 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+
+import useGetBrowserWidth from './use-get-browser-width';
+
+export function useTimeBottomSheet(isBottomSheetOpen: boolean) {
+  const [showTimePicker, setShowTimePicker] = useState(false);
+  const width = useGetBrowserWidth();
+
+  useEffect(() => {
+    if (isBottomSheetOpen) {
+      setTimeout(() => {
+        setShowTimePicker(true);
+      }, 150);
+    } else setShowTimePicker(false);
+  }, [isBottomSheetOpen]);
+
+  return { width, showTimePicker };
+}

--- a/features/record/styles/time-picker.css
+++ b/features/record/styles/time-picker.css
@@ -1,3 +1,0 @@
-.custom-picker input {
-  visibility: hidden;
-}


### PR DESCRIPTION
## 🤔 어떤 문제가 발생했나요?

- time-picker가 바텀 시트보다 먼저 올라오는 현상이 있었습니다.

## 🎉 어떻게 해결했나요?

- time-picker만을 위한 상태를 하나 추가하여 해결하였습니다.

### 📷 이미지 첨부 (Option)

https://github.com/user-attachments/assets/79167cd2-0dbf-42b0-8ece-7fc334a1365d

### ⚠️ 유의할 점! (Option)

- NA
