### PR TITLE
fix: accessToken 재발급 시 undefined 생성 건을 수정했습니다.

### DIFF
--- a/apis/fetch-data.ts
+++ b/apis/fetch-data.ts
@@ -48,7 +48,7 @@ export async function fetchData<T>(
 
       if (refreshResponse.ok) {
         const data = (await refreshResponse.json()) as NewTokenData;
-        const newAccessToken = `Bearer ${data?.data?.accessToken}`;
+        const newAccessToken = `Bearer ${data.data.accessToken}`;
 
         cookieStore.set('accessToken', newAccessToken, {
           maxAge: 3600, // 1시간

--- a/app/login/login-client.tsx
+++ b/app/login/login-client.tsx
@@ -15,6 +15,10 @@ export default function LoginClient() {
     window.location.href = `https://accounts.google.com/o/oauth2/v2/auth?client_id=${process.env.NEXT_PUBLIC_GOOGLE_CLIENT_ID}&redirect_uri=${process.env.NEXT_PUBLIC_GOOGLE_REDIRECT_URI}&response_type=code&scope=email profile&prompt=select_account&access_type=offline`;
   };
 
+  const appleLogin = () => {
+    window.location.href = ` https://appleid.apple.com/auth/authorize?client_id=${process.env.NEXT_PUBLIC_APPLE_CLIENT_ID}&redirect_uri=${process.env.NEXT_PUBLIC_APPLE_REDIRECT_URI}&response_type=code id_token&scope=name email&response_mode=form_post`;
+  };
+
   return (
     <div className={loginPage}>
       <div className={logo}>Swimie</div>
@@ -31,7 +35,7 @@ export default function LoginClient() {
             <span>Google로 로그인</span>
           </div>
         </button>
-        <button className={appleLoginButton}>
+        <button className={appleLoginButton} onClick={appleLogin}>
           <div className={buttonContent}>
             <AppleLogoIcon />
             <span>Apple ID로 로그인</span>

--- a/components/atoms/button/button.stories.tsx
+++ b/components/atoms/button/button.stories.tsx
@@ -10,7 +10,7 @@ const meta: Meta<typeof Button> = {
   tags: ['autodocs'],
   decorators: [
     (Story) => (
-      <div className={css({ margin: 10 })}>
+      <div className={css({ m: 10 })}>
         <Story />
       </div>
     ),

--- a/components/atoms/button/button.tsx
+++ b/components/atoms/button/button.tsx
@@ -14,9 +14,9 @@ export const Button = ({
   variant,
   buttonType,
   interaction = 'normal',
-  className,
   type,
   onClick,
+  className,
 }: ButtonProps) => {
   const baseStyles = flex({
     alignItems: 'center',


### PR DESCRIPTION
<!-- 작성 예시 -->
<!-- # 어떤 문제가 발생했나요? -->
<!-- - 간략한 문제 설명 -->
<!-- - 문제 관련 링크 등등 -->
<!-- Ex) React v18 version update에 후 테스트에서 에러가 발생합니다.
  라이브러리의 버전이 호환이 되지않아서 문제입니다. -->

<!-- # 어떻게 해결했나요? -->
<!-- - 동작 방식 등 수정힌 코드에 대한 설명 -->
<!-- Ex) 라이브러리의 버전을 업데이트하고, v18을 사용할 수 있도록 dev dependency로 설치해주었습니다. -->

<!-- # 이미지 첨부 (Option) -->
<!-- - 이번 PR의 동작 이해를 돕는 GIF나 이미지 파일 첨부! -->
<!-- - 만약 없다면, NA 혹은 비워둡시다~ -->

<!-- # 유의할 점 (Option) -->
<!-- - 추가적으로 고민중이거나 조언을 구하고 싶은 내용, 어떤 것을 중점으로 리뷰를 해줬으면 좋겠는지 등등 작성 -->
<!-- - 만약 없다면, NA 혹은 비워둡시다~ -->

## 🤔 어떤 문제가 발생했나요?

- refreshToken만 존재할 경우 refreshToken을 서버 쪽으로 보내 새로운 accessToken을 발급받아야 합니다. 이때 refreshToken이 유효하지 않는 경우 accessToken이 undefined로도 들어오게 됩니다.

## 🎉 어떻게 해결했나요?

- middleware에 유효하지 않은 refreshToken으로 accessToken을 요청할 경우 분기 처리를 해 login page로 이동하도록 했습니다.

### 📷 이미지 첨부 (Option)

**before (현재 배포환경)**
유효하지 않은 refreshToken으로 accessToken을 재발급 받으니 undefined로 들어옵니다.

https://github.com/user-attachments/assets/a2971037-55dd-4ff7-80e0-9758606103c5


**after (작업 환경)**
refreshToken이 유효하지 않기 때문에 response도 유효하지 않아, /login으로 이동됩니다.

https://github.com/user-attachments/assets/f038a0a6-722d-487f-aa49-1bda70d99fa1


### ⚠️ 유의할 점! (Option)

-

<!-- PR merge시 닫을 이슈가 있다면, 번호를 작성해주세요 -->
<!-- Ex) close #12 -->
