### PR TITLE
feat: 기록 상세 > 응원 조회 영역 마크업

### DIFF
--- a/app/record-detail/[id]/page.tsx
+++ b/app/record-detail/[id]/page.tsx
@@ -54,13 +54,17 @@ export default async function RecordDetail({ params }: RecordDetail) {
         </div>
       </HeaderBar>
       <article className={containerStyle}>
-        {/* preview section */}
-        <DynamicPreviewSection data={data} />
+        <div>
+          {/* cheer section */}
+          <DynamicCheerSection data={data} />
+          {/* preview section */}
+          <DynamicPreviewSection data={data} />
+        </div>
+
         {/* description section */}
         <DetailDescriptionSection data={data} />
         {/* diary section */}
         <DetailDiarySection data={data} />
-        <DynamicCheerSection data={data} />
       </article>
     </>
   );

--- a/app/record-detail/[id]/page.tsx
+++ b/app/record-detail/[id]/page.tsx
@@ -60,7 +60,7 @@ export default async function RecordDetail({ params }: RecordDetail) {
         <DetailDescriptionSection data={data} />
         {/* diary section */}
         <DetailDiarySection data={data} />
-        <DynamicCheerSection />
+        <DynamicCheerSection data={data} />
       </article>
     </>
   );

--- a/components/molecules/dialog/dialog.tsx
+++ b/components/molecules/dialog/dialog.tsx
@@ -54,6 +54,8 @@ export const Dialog = ({
                   onClick={buttons.confirm.onClick}
                   label={buttons.confirm.text}
                   size="large"
+                  buttonType="primary"
+                  variant="solid"
                 />
               )}
             </div>

--- a/features/record-detail/components/cheer-item.tsx
+++ b/features/record-detail/components/cheer-item.tsx
@@ -1,23 +1,32 @@
-import { cva } from '@/styled-system/css';
+import { css, cva } from '@/styled-system/css';
 
 import { DetailCheerItem } from '../types';
 
 type CheerItem = {
   isSelected?: boolean;
   onClick?: () => void;
+  nickname?: string;
+  size?: 'small' | 'medium';
 } & DetailCheerItem;
 
 // TODO: 로직 구현에 맞춰 props 수정
-export const CheerItem = ({ isSelected, onClick, ...item }: CheerItem) => {
+export const CheerItem = ({
+  isSelected,
+  onClick,
+  nickname,
+  size = 'medium',
+  ...item
+}: CheerItem) => {
   if (!item?.emoji?.length && !item?.comment?.length) return null;
   return (
     // NOTE: isSelected undefined 대응하여 Boolean 사용
     <button
-      className={containerStyle({ isSelected: Boolean(isSelected) })}
+      className={containerStyle({ isSelected: Boolean(isSelected), size })}
       onClick={onClick}
     >
       {item?.emoji?.length && <div>{item.emoji}</div>}
       {item?.comment?.length && <p>{item.comment}</p>}
+      {nickname?.length && <p className={nicknameStyle}>{nickname}</p>}
     </button>
   );
 };
@@ -27,13 +36,12 @@ const containerStyle = cva({
     width: 'fit-content',
     display: 'flex',
     gap: '8px',
-    p: '8px 14px',
     color: 'text.normal',
-    textStyle: 'body1.normal',
     fontWeight: 'medium',
     border: '1px solid',
     rounded: '8px',
     cursor: 'pointer',
+    flexShrink: 0,
   },
   variants: {
     isSelected: {
@@ -48,5 +56,22 @@ const containerStyle = cva({
         backgroundColor: 'white',
       },
     },
+    size: {
+      small: {
+        p: '7px 12px',
+        textStyle: 'label1.normal',
+      },
+      medium: {
+        p: '8px 14px',
+        textStyle: 'body1.normal',
+      },
+    },
   },
+});
+
+const nicknameStyle = css({
+  ml: '4px',
+  textStyle: 'label1.normal',
+  color: 'text.alternative',
+  fontWeight: 'medium',
 });

--- a/features/record-detail/components/cheer-item.tsx
+++ b/features/record-detail/components/cheer-item.tsx
@@ -1,19 +1,24 @@
 import { cva } from '@/styled-system/css';
 
+import { DetailCheerItem } from '../types';
+
 type CheerItem = {
-  icon?: string;
-  title?: string;
   isSelected?: boolean;
-};
+  onClick?: () => void;
+} & DetailCheerItem;
+
 // TODO: 로직 구현에 맞춰 props 수정
-export const CheerItem = ({ icon, title, isSelected }: CheerItem) => {
-  if (!icon?.length && !title?.length) return null;
+export const CheerItem = ({ isSelected, onClick, ...item }: CheerItem) => {
+  if (!item?.emoji?.length && !item?.comment?.length) return null;
   return (
     // NOTE: isSelected undefined 대응하여 Boolean 사용
-    <div className={containerStyle({ isSelected: Boolean(isSelected) })}>
-      {icon?.length && <div>{icon}</div>}
-      {title?.length && <p>{title}</p>}
-    </div>
+    <button
+      className={containerStyle({ isSelected: Boolean(isSelected) })}
+      onClick={onClick}
+    >
+      {item?.emoji?.length && <div>{item.emoji}</div>}
+      {item?.comment?.length && <p>{item.comment}</p>}
+    </button>
   );
 };
 
@@ -28,6 +33,7 @@ const containerStyle = cva({
     fontWeight: 'medium',
     border: '1px solid',
     rounded: '8px',
+    cursor: 'pointer',
   },
   variants: {
     isSelected: {

--- a/features/record-detail/sections/detail-cheer.tsx
+++ b/features/record-detail/sections/detail-cheer.tsx
@@ -1,5 +1,7 @@
 'use client';
 
+import { useState } from 'react';
+
 import { Button } from '@/components/atoms';
 import { BottomSheet } from '@/components/molecules';
 import { useBottomSheet } from '@/hooks';
@@ -7,19 +9,72 @@ import { css } from '@/styled-system/css';
 import { flex, grid } from '@/styled-system/patterns';
 
 import { CheerItem } from '../components';
+import { RecordDetailType } from '../types';
 
-export const DetailCheer = () => {
+const initialCheerList = [
+  {
+    emoji: '🔥',
+    comment: '오늘도 힘내요!',
+    isSelected: false,
+  },
+  {
+    emoji: '🦭',
+    comment: '물개세요?',
+    isSelected: false,
+  },
+  {
+    emoji: '🏊',
+    isSelected: false,
+  },
+  {
+    emoji: '👏',
+    isSelected: false,
+  },
+  {
+    emoji: '🏊‍♂️',
+    comment: '진정한 수영인으로 인정합니다',
+    isSelected: false,
+  },
+  {
+    emoji: '🏊‍♂️',
+    comment: '다음에 같이 수영해요',
+    isSelected: false,
+  },
+  {
+    emoji: '😲',
+    comment: '대단해요!',
+    isSelected: false,
+  },
+];
+
+export const DetailCheer = ({ data }: { data: RecordDetailType }) => {
+  const [cheerList, setCheerList] = useState(initialCheerList);
   const [isOpen, open, close] = useBottomSheet();
 
-  const handleClickCheerButton = () => {
-    open();
+  const handleClickCheerItem = (index: number) => {
+    setCheerList((prev) =>
+      prev.map((item, idx) =>
+        idx === index ? { ...item, isSelected: !item.isSelected } : item,
+      ),
+    );
+  };
+
+  const handleClickSendCheer = () => {
+    const selectedCheerList = cheerList.filter(({ isSelected }) => isSelected);
+    if (!selectedCheerList.length) {
+      alert('응원 문구를 선택해주세요.');
+      return;
+    }
+
+    // TODO: 응원 보내기 api 연동
+    console.log('send!', selectedCheerList);
   };
 
   // TODO: 응원하기 flow 구현
   return (
     <>
-      <button className={floatingCheerButton} onClick={handleClickCheerButton}>
-        정지영님에게 응원 보내기 👏
+      <button className={floatingCheerButton} onClick={open}>
+        {data.member?.name}님에게 응원 보내기 👏
       </button>
       <BottomSheet
         header={{ title: '응원 보내기' }}
@@ -27,17 +82,13 @@ export const DetailCheer = () => {
         onClose={close}
       >
         <div className={tagContainerStyle}>
-          <CheerItem icon="🔥" title="오늘도 힘내요!" />
-          <CheerItem icon="🦭" title="물개세요?" />
-          <CheerItem icon="🏊‍♀️️" />
-          <CheerItem icon="👏" />
-          <CheerItem
-            icon="🏊‍♂️"
-            title="진정한 수영인으로 인정합니다"
-            isSelected={true}
-          />
-          <CheerItem icon="🏊" title="다음에 같이 수영해요" />
-          <CheerItem icon="😲" title="대단해요!" />
+          {cheerList.map((item, index) => (
+            <CheerItem
+              key={index}
+              onClick={() => handleClickCheerItem(index)}
+              {...item}
+            />
+          ))}
         </div>
         <div className={buttonContainerStyle}>
           <Button
@@ -51,6 +102,7 @@ export const DetailCheer = () => {
             size="large"
             variant="solid"
             buttonType="primary"
+            onClick={handleClickSendCheer}
           />
         </div>
       </BottomSheet>

--- a/features/record-detail/sections/detail-cheer.tsx
+++ b/features/record-detail/sections/detail-cheer.tsx
@@ -4,7 +4,7 @@ import { useState } from 'react';
 
 import { Button } from '@/components/atoms';
 import { BottomSheet } from '@/components/molecules';
-import { useBottomSheet } from '@/hooks';
+import { useBottomSheet, useDragScroll } from '@/hooks';
 import { css } from '@/styled-system/css';
 import { flex, grid } from '@/styled-system/patterns';
 
@@ -50,6 +50,7 @@ const initialCheerList = [
 export const DetailCheer = ({ data }: { data: RecordDetailType }) => {
   const [cheerList, setCheerList] = useState(initialCheerList);
   const [isOpen, open, close] = useBottomSheet();
+  const { sliderRef } = useDragScroll();
 
   const handleClickCheerItem = (index: number) => {
     setCheerList((prev) =>
@@ -70,10 +71,50 @@ export const DetailCheer = ({ data }: { data: RecordDetailType }) => {
     console.log('send!', selectedCheerList);
   };
 
-  // TODO: 응원하기 flow 구현
   return (
     <>
-      <button className={floatingCheerButton} onClick={open}>
+      <div className={slider.containerStyle} ref={sliderRef}>
+        <div className={slider.wrapperStyle}>
+          <CheerItem
+            emoji="🖤"
+            comment="너무 멋져요"
+            nickname="수영왕지영"
+            size="small"
+          />
+          <CheerItem
+            emoji="🖤"
+            comment="너무 멋져요"
+            nickname="수영왕지영"
+            size="small"
+          />
+          <CheerItem
+            emoji="🖤"
+            comment="너무 멋져요"
+            nickname="수영왕지영"
+            size="small"
+          />
+          <CheerItem
+            emoji="🖤"
+            comment="너무 멋져요"
+            nickname="수영왕지영"
+            size="small"
+          />
+          <CheerItem
+            emoji="🖤"
+            comment="너무 멋져요"
+            nickname="수영왕지영"
+            size="small"
+          />
+          <CheerItem
+            emoji="🖤"
+            comment="너무 멋져요"
+            nickname="수영왕지영"
+            size="small"
+          />
+          <button className={slider.entireCheerButton}>응원 전체보기</button>
+        </div>
+      </div>
+      <button className={cheerButtonWrapperStyle} onClick={open}>
         {data.member?.name}님에게 응원 보내기 👏
       </button>
       <BottomSheet
@@ -110,7 +151,33 @@ export const DetailCheer = ({ data }: { data: RecordDetailType }) => {
   );
 };
 
-const floatingCheerButton = css({
+const slider = {
+  containerStyle: css({
+    overflowX: 'scroll',
+
+    '&::-webkit-scrollbar': {
+      display: 'none',
+    },
+  }),
+
+  wrapperStyle: flex({
+    gap: '10px',
+    width: 'max-content',
+    backgroundColor: 'white',
+    p: '20px 20px 0px',
+  }),
+
+  entireCheerButton: css({
+    textStyle: 'label1.normal',
+    fontWeight: 'medium',
+    color: 'background.white',
+    backgroundColor: 'text.neutral',
+    rounded: '7px',
+    p: '7px 12px',
+  }),
+};
+
+const cheerButtonWrapperStyle = css({
   position: 'fixed',
   right: '20px',
   bottom: '35px',

--- a/features/record-detail/sections/detail-cheer.tsx
+++ b/features/record-detail/sections/detail-cheer.tsx
@@ -73,6 +73,7 @@ export const DetailCheer = ({ data }: { data: RecordDetailType }) => {
 
   return (
     <>
+      {/* TODO: 응원 조회 api 연동 및 모달 open 기능 구현 */}
       <div className={slider.containerStyle} ref={sliderRef}>
         <div className={slider.wrapperStyle}>
           <CheerItem

--- a/features/record-detail/types/index.ts
+++ b/features/record-detail/types/index.ts
@@ -48,3 +48,8 @@ export type RecordDetailType = {
   totalMeter?: number;
   diary?: string;
 };
+
+export type DetailCheerItem = {
+  emoji?: string;
+  comment?: string;
+};

--- a/hooks/index.ts
+++ b/hooks/index.ts
@@ -1,3 +1,4 @@
 export * from './use-bottom-sheet';
 export * from './use-calendar-data';
+export * from './use-drag-scroll';
 export * from './use-intersection-observer';

--- a/hooks/use-drag-scroll.ts
+++ b/hooks/use-drag-scroll.ts
@@ -1,5 +1,8 @@
 import { useEffect, useRef, useState } from 'react';
 
+/**
+ * @description 마우스로 드래그하고자 하는 영역에 사용합니다.
+ */
 export const useDragScroll = () => {
   const sliderRef = useRef<HTMLDivElement>(null);
   const isDown = useRef<boolean>(false);

--- a/hooks/use-drag-scroll.ts
+++ b/hooks/use-drag-scroll.ts
@@ -1,3 +1,5 @@
+'use client';
+
 import { useEffect, useRef, useState } from 'react';
 
 /**

--- a/hooks/use-drag-scroll.ts
+++ b/hooks/use-drag-scroll.ts
@@ -1,0 +1,62 @@
+import { useEffect, useRef, useState } from 'react';
+
+export const useDragScroll = () => {
+  const sliderRef = useRef<HTMLDivElement>(null);
+  const isDown = useRef<boolean>(false);
+  const startX = useRef<number | null>(null);
+  const scrollLeft = useRef<number | null>(null);
+  const [isDragging, setIsDragging] = useState(false);
+
+  useEffect(() => {
+    const sliderElement = sliderRef.current;
+
+    if (sliderElement) {
+      const handleMouseDown = (e: MouseEvent) => {
+        isDown.current = true;
+        startX.current = e.pageX - sliderElement.offsetLeft;
+        scrollLeft.current = sliderElement.scrollLeft;
+        sliderElement.style.cursor = 'grabbing';
+      };
+
+      const handleMouseFocused = () => {
+        isDown.current = false;
+        sliderElement.style.cursor = '';
+      };
+
+      const handleMouseUp = () => {
+        handleMouseFocused();
+        setIsDragging(false);
+      };
+
+      const handleMouseMove = (e: MouseEvent) => {
+        if (!isDown.current) {
+          return;
+        }
+        e.preventDefault();
+
+        const offset = e.pageX - sliderElement.offsetLeft;
+        const walk = offset - (startX.current ?? 0);
+
+        if (Math.abs(walk) > 20) {
+          setIsDragging(true);
+        }
+
+        sliderElement.scrollLeft = (scrollLeft.current ?? 0) - walk;
+      };
+
+      sliderElement.addEventListener('mousedown', handleMouseDown);
+      sliderElement.addEventListener('mouseenter', handleMouseFocused);
+      sliderElement.addEventListener('mouseup', handleMouseUp);
+      sliderElement.addEventListener('mousemove', handleMouseMove);
+
+      return () => {
+        sliderElement.removeEventListener('mousedown', handleMouseDown);
+        sliderElement.removeEventListener('mouseenter', handleMouseFocused);
+        sliderElement.removeEventListener('mouseup', handleMouseUp);
+        sliderElement.removeEventListener('mousemove', handleMouseMove);
+      };
+    }
+  }, []);
+
+  return { sliderRef, isDragging };
+};


### PR DESCRIPTION
<!-- 작성 예시 -->
<!-- # 어떤 문제가 발생했나요? -->
<!-- - 간략한 문제 설명 -->
<!-- - 문제 관련 링크 등등 -->
<!-- Ex) React v18 version update에 후 테스트에서 에러가 발생합니다.
  라이브러리의 버전이 호환이 되지않아서 문제입니다. -->

<!-- # 어떻게 해결했나요? -->
<!-- - 동작 방식 등 수정힌 코드에 대한 설명 -->
<!-- Ex) 라이브러리의 버전을 업데이트하고, v18을 사용할 수 있도록 dev dependency로 설치해주었습니다. -->

<!-- # 이미지 첨부 (Option) -->
<!-- - 이번 PR의 동작 이해를 돕는 GIF나 이미지 파일 첨부! -->
<!-- - 만약 없다면, NA 혹은 비워둡시다~ -->

<!-- # 유의할 점 (Option) -->
<!-- - 추가적으로 고민중이거나 조언을 구하고 싶은 내용, 어떤 것을 중점으로 리뷰를 해줬으면 좋겠는지 등등 작성 -->
<!-- - 만약 없다면, NA 혹은 비워둡시다~ -->

## 🤔 어떤 문제가 발생했나요?

-

## 🎉 어떻게 해결했나요?

- 기록 상세 페이지 내부 응원 조회 영역 마크업 작업입니다.
    - PC에서도 드래그가 가능하도록 `useDragScroll` hook을 구현했습니다.
        - `slideRef`를 꺼내와 container div에 ref 지정 시, **마우스 이벤트에 따라 해당 영역을 드래그**할 수 있습니다. (PC 대응)
        - 터치패드를 사용한 가로 스크롤 기능도 사용할 수 있습니다. (css)
    - api 연동을 위한 TODO 주석을 추가했습니다.


### TODO
1. api 연동
2. 기능 구현
3. 응원하기 바텀 시트를 다른 영역에서도 사용할 수 있게 공통 분리
4. cheer-item component 공통 분리

### 📷 이미지 첨부 (Option)

1. PC

https://github.com/user-attachments/assets/3e0dbd1d-9785-4392-8b3d-ce9f89b59971


5.  MO

https://github.com/user-attachments/assets/c22b4847-df85-4382-8b41-b6c8e3ddeb5d



### ⚠️ 유의할 점! (Option)

-

<!-- PR merge시 닫을 이슈가 있다면, 번호를 작성해주세요 -->
<!-- Ex) close #12 -->
