### PR TITLE
fix: 기록 상세 페이지 수영 시간 포맷팅 수정

### DIFF
--- a/features/record-detail/sections/detail-cheer.tsx
+++ b/features/record-detail/sections/detail-cheer.tsx
@@ -190,6 +190,7 @@ const cheerButtonWrapperStyle = css({
   rounded: 'full',
   cursor: 'pointer',
   shadow: 'emphasize',
+  zIndex: 100,
 
   '@media (min-width: 600px)': {
     right: 'calc(50% - 300px + 20px);',

--- a/features/record-detail/sections/detail-cheer.tsx
+++ b/features/record-detail/sections/detail-cheer.tsx
@@ -55,7 +55,9 @@ export const DetailCheer = ({ data }: { data: RecordDetailType }) => {
   const handleClickCheerItem = (index: number) => {
     setCheerList((prev) =>
       prev.map((item, idx) =>
-        idx === index ? { ...item, isSelected: !item.isSelected } : item,
+        idx === index
+          ? { ...item, isSelected: !item.isSelected }
+          : { ...item, isSelected: false },
       ),
     );
   };

--- a/features/record-detail/sections/detail-description.tsx
+++ b/features/record-detail/sections/detail-description.tsx
@@ -13,6 +13,16 @@ export const DetailDescriptionSection = ({
 }) => {
   const { pool, duration, memoryDetail } = data;
 
+  const getFormatDurationTime = () => {
+    if (!duration) return undefined;
+
+    const { hour, minute } = getFormatTime({ timeStr: duration });
+    const hourStr = hour === 0 ? '' : `${hour}시간 `;
+    const minuteStr = minute === 0 ? '' : `${minute}분`;
+
+    return `${hourStr}${minuteStr}`;
+  };
+
   // NOTE: data type이 number이므로 0일 경우 예외처리를 위해 Boolean 사용
   const heartRate = Boolean(memoryDetail?.heartRate)
     ? `${memoryDetail?.heartRate} bpm`
@@ -31,7 +41,7 @@ export const DetailDescriptionSection = ({
         <SwimDescriptionItem title="수영 장소" value={pool?.name} />
         <SwimDescriptionItem
           title="수영 시간"
-          value={duration && `${getFormatTime({ timeStr: duration }).minute}분`}
+          value={getFormatDurationTime()}
         />
       </div>
 

--- a/features/record-detail/sections/detail-diary.tsx
+++ b/features/record-detail/sections/detail-diary.tsx
@@ -101,4 +101,5 @@ const diaryDetailStyle = css({
   textStyle: 'body2.leading',
   color: 'text.neutral',
   backgroundColor: 'background.gray',
+  textWrap: 'wrap',
 });


### PR DESCRIPTION
<!-- 작성 예시 -->
<!-- # 어떤 문제가 발생했나요? -->
<!-- - 간략한 문제 설명 -->
<!-- - 문제 관련 링크 등등 -->
<!-- Ex) React v18 version update에 후 테스트에서 에러가 발생합니다.
  라이브러리의 버전이 호환이 되지않아서 문제입니다. -->

<!-- # 어떻게 해결했나요? -->
<!-- - 동작 방식 등 수정힌 코드에 대한 설명 -->
<!-- Ex) 라이브러리의 버전을 업데이트하고, v18을 사용할 수 있도록 dev dependency로 설치해주었습니다. -->

<!-- # 이미지 첨부 (Option) -->
<!-- - 이번 PR의 동작 이해를 돕는 GIF나 이미지 파일 첨부! -->
<!-- - 만약 없다면, NA 혹은 비워둡시다~ -->

<!-- # 유의할 점 (Option) -->
<!-- - 추가적으로 고민중이거나 조언을 구하고 싶은 내용, 어떤 것을 중점으로 리뷰를 해줬으면 좋겠는지 등등 작성 -->
<!-- - 만약 없다면, NA 혹은 비워둡시다~ -->

## 🤔 어떤 문제가 발생했나요?

- duration이 분 단위로만 보여지는 이슈를 수정했습니다.

## 🎉 어떻게 해결했나요?

- getFormatDurationTime 함수로 Duration 문자열을 시간,분 단위로 포맷합니다.

### 📷 이미지 첨부 (Option)

<img width="406" alt="스크린샷 2024-08-14 오전 12 58 12" src="https://github.com/user-attachments/assets/16c575e5-fe06-441b-86f4-5ec0b93d716b">

### ⚠️ 유의할 점! (Option)

-

<!-- PR merge시 닫을 이슈가 있다면, 번호를 작성해주세요 -->
<!-- Ex) close #12 -->
