### PR TITLE
fix: time-picker가 PC에서 왼쪽으로 치우쳐지는 현상 수정

### DIFF
--- a/features/record/components/organisms/time-bottom-sheet.tsx
+++ b/features/record/components/organisms/time-bottom-sheet.tsx
@@ -125,7 +125,6 @@ const layoutStyles = {
 const panelStyles = css({
   position: 'fixed',
   bottom: '82px',
-  left: 0,
   textStyle: 'heading3',
   fontWeight: 400,
 });


### PR DESCRIPTION
## 🤔 어떤 문제가 발생했나요?

- PC 버전에서 time-picker가 왼쪽으로 치우쳐있는 현상이 있었습니다.

## 🎉 어떻게 해결했나요?

- left:0 속성을 제거하였습니다.

### 📷 이미지 첨부 (Option)

- PC

<img width="677" alt="image" src="https://github.com/user-attachments/assets/b45ee1ef-c903-4df9-a16f-64208a569569">

- Mobile

<img width="292" alt="image" src="https://github.com/user-attachments/assets/ab99da86-b063-4167-a3f1-a286950c6cbd">

### ⚠️ 유의할 점! (Option)

- NA