### PR TITLE
fix: header-bar 컴포넌트에 max-width 설정

### DIFF
--- a/components/molecules/header-bar/header-bar.tsx
+++ b/components/molecules/header-bar/header-bar.tsx
@@ -153,6 +153,7 @@ const layoutStyles = {
     position: 'fixed',
     top: 0,
     w: 'full',
+    maxW: 'maxWidth',
     display: 'flex',
     alignItems: 'center',
     minHeight: '44px',


### PR DESCRIPTION
## 🤔 어떤 문제가 발생했나요?

- header-bar 컴포넌트에 max-width 속성이 적용되지 않았습니다.
 
## 🎉 어떻게 해결했나요?

- max-width 속성을 부여하였습니다.

### 📷 이미지 첨부 (Option)

<img width="573" alt="image" src="https://github.com/user-attachments/assets/ea9882dd-fb64-4ddf-845c-d31dd7385697">

### ⚠️ 유의할 점! (Option)

- NA
