### PR TITLE
feat: 응원하기 모달 마크업 작업 + 응원 바텀시트를 분리합니다.

### DIFF
--- a/app/record-detail/[id]/page.tsx
+++ b/app/record-detail/[id]/page.tsx
@@ -57,6 +57,7 @@ export default async function RecordDetail({ params }: RecordDetail) {
           {[{ component: <EditButton memoryId={params.id} />, key: 'edit' }]}
         </HeaderBar.RightContent>
       </HeaderBar>
+
       <article className={containerStyle}>
         <div>
           {/* cheer section */}

--- a/features/record-detail/components/cheer-bottom-sheet.tsx
+++ b/features/record-detail/components/cheer-bottom-sheet.tsx
@@ -1,0 +1,62 @@
+import { Button } from '@/components/atoms';
+import { BottomSheet, BottomSheetProps } from '@/components/molecules';
+import { flex, grid } from '@/styled-system/patterns';
+
+import { DetailCheerItem } from '../types';
+import { CheerItem } from './cheer-item';
+
+type CheerBottomSheet = {
+  cheerList: DetailCheerItem[];
+  onClickCheerItem: (index: number) => void;
+  onClickSendCheer: () => void;
+} & BottomSheetProps;
+export const CheerBottomSheet = ({
+  header,
+  isOpen,
+  onClose,
+  cheerList,
+  onClickCheerItem,
+  onClickSendCheer,
+}: CheerBottomSheet) => {
+  return (
+    <BottomSheet header={header} isOpen={isOpen} onClose={onClose}>
+      <div className={tagContainerStyle}>
+        {cheerList.map((item, index) => (
+          <CheerItem
+            key={index}
+            onClick={() => onClickCheerItem(index)}
+            {...item}
+          />
+        ))}
+      </div>
+      <div className={buttonContainerStyle}>
+        <Button
+          label="닫기"
+          variant="outlined"
+          size="large"
+          onClick={onClose}
+        />
+        <Button
+          label="보내기"
+          size="large"
+          variant="solid"
+          buttonType="primary"
+          onClick={onClickSendCheer}
+        />
+      </div>
+    </BottomSheet>
+  );
+};
+
+const tagContainerStyle = flex({
+  wrap: 'wrap',
+  gap: '10px',
+  rowGap: '10px',
+  p: '8px 20px',
+});
+
+const buttonContainerStyle = grid({
+  gap: '10px',
+  p: '16px 20px 0 20px',
+  gridTemplateColumns: '1fr 1fr',
+});

--- a/features/record-detail/components/cheer-modal-item.tsx
+++ b/features/record-detail/components/cheer-modal-item.tsx
@@ -1,0 +1,89 @@
+import { Image } from '@/components/atoms';
+import { css } from '@/styled-system/css';
+import { flex } from '@/styled-system/patterns';
+
+import { DetailCheerItem } from '../types';
+
+type CheerModalItem = {
+  reactionId: number;
+  nickname: string;
+  profileImageUrl: string;
+} & DetailCheerItem;
+
+export const CheerModalItem = ({
+  // reactionId,
+  nickname,
+  profileImageUrl,
+  emoji,
+  comment,
+}: CheerModalItem) => {
+  return (
+    <div className={containerStyle}>
+      <div className={profile.wrapperStyle}>
+        <div className={profile.imageStyle}>
+          <Image
+            src={profileImageUrl}
+            width={16}
+            height={16}
+            alt="profile image"
+            style={{ objectFit: 'cover' }}
+          />
+        </div>
+        <h3 className={profile.nickNameStyle}>{nickname}</h3>
+      </div>
+      <div className={contentWrapperStyle}>
+        <div className={commentStyle}>
+          <span>{emoji}</span>
+          {comment && <span>{comment}</span>}
+        </div>
+        <button className={removeButtonStyle}>삭제</button>
+      </div>
+    </div>
+  );
+};
+
+const containerStyle = flex({
+  direction: 'column',
+  gap: '10px',
+  py: '16px',
+  borderTop: '1px solid',
+  borderColor: 'line.alternative',
+});
+
+const profile = {
+  wrapperStyle: flex({
+    alignItems: 'center',
+    gap: '6px',
+  }),
+
+  imageStyle: css({
+    rounded: 'full',
+    w: '16px',
+    h: '16px',
+    overflow: 'hidden',
+  }),
+
+  nickNameStyle: css({
+    textStyle: 'label1.normal',
+    fontWeight: 'medium',
+    color: 'text.alternative',
+  }),
+};
+
+const contentWrapperStyle = flex({
+  justifyContent: 'space-between',
+  alignItems: 'center',
+});
+
+const commentStyle = flex({
+  gap: '6px',
+  textStyle: 'heading6',
+  fontWeight: 'bold',
+  color: 'text.normal',
+});
+
+const removeButtonStyle = css({
+  textStyle: 'label1.normal',
+  fontWeight: 'regular',
+  color: 'text.alternative',
+});

--- a/features/record-detail/components/cheer-modal.tsx
+++ b/features/record-detail/components/cheer-modal.tsx
@@ -66,7 +66,8 @@ export const CheerModal = ({
 
 const contentWrapper = css({
   flexGrow: 1,
-  height: '332px',
+  height: 'full',
+  maxHeight: '332px',
   overflowY: 'scroll',
 
   '&::-webkit-scrollbar': {

--- a/features/record-detail/components/cheer-modal.tsx
+++ b/features/record-detail/components/cheer-modal.tsx
@@ -1,0 +1,75 @@
+import { Modal, ModalProps } from '@/components/molecules';
+import { css } from '@/styled-system/css';
+
+import { CheerModalItem } from './cheer-modal-item';
+
+const initialCheerList = [
+  {
+    reactionId: 32,
+    emoji: '🔥',
+    comment: '오늘도 힘내요!',
+    nickname: '이승은',
+    profileImageUrl: '',
+  },
+  {
+    reactionId: 31,
+    emoji: '🦭',
+    comment: '물개세요?',
+    nickname: '준영',
+    profileImageUrl: '',
+  },
+  {
+    reactionId: 30,
+    emoji: '🎯',
+    comment: '목표 달성!',
+    nickname: '최유영',
+    profileImageUrl: '',
+  },
+  {
+    reactionId: 29,
+    emoji: '👏🏼',
+    nickname: '신민철',
+    profileImageUrl: '',
+  },
+];
+
+// TODO: data 연동 및 props 수정
+type CheerModal = {
+  cheerList?: string[];
+} & ModalProps;
+export const CheerModal = ({
+  isOpen,
+  onClose,
+  title,
+  description,
+}: CheerModal) => {
+  return (
+    <Modal
+      isOpen={isOpen}
+      onClose={onClose}
+      title={title}
+      description={description}
+      button={{
+        text: '닫기',
+        onClick: onClose,
+      }}
+      isBodyFadeOut={true}
+    >
+      <div className={contentWrapper}>
+        {initialCheerList.map((item) => (
+          <CheerModalItem {...item} key={item.reactionId} />
+        ))}
+      </div>
+    </Modal>
+  );
+};
+
+const contentWrapper = css({
+  flexGrow: 1,
+  height: '332px',
+  overflowY: 'scroll',
+
+  '&::-webkit-scrollbar': {
+    display: 'none',
+  },
+});

--- a/features/record-detail/components/index.ts
+++ b/features/record-detail/components/index.ts
@@ -1,4 +1,6 @@
+export * from './cheer-bottom-sheet';
 export * from './cheer-item';
+export * from './cheer-modal';
 export * from './date-picker';
 export * from './edit-button';
 export * from './swim-description-item';

--- a/features/record-detail/sections/detail-cheer.tsx
+++ b/features/record-detail/sections/detail-cheer.tsx
@@ -2,13 +2,11 @@
 
 import { useState } from 'react';
 
-import { Button } from '@/components/atoms';
-import { BottomSheet } from '@/components/molecules';
-import { useBottomSheet, useDragScroll } from '@/hooks';
+import { useBottomSheet, useDragScroll, useModal } from '@/hooks';
 import { css } from '@/styled-system/css';
-import { flex, grid } from '@/styled-system/patterns';
+import { flex } from '@/styled-system/patterns';
 
-import { CheerItem } from '../components';
+import { CheerBottomSheet, CheerItem, CheerModal } from '../components';
 import { RecordDetailType } from '../types';
 
 const initialCheerList = [
@@ -49,7 +47,17 @@ const initialCheerList = [
 
 export const DetailCheer = ({ data }: { data: RecordDetailType }) => {
   const [cheerList, setCheerList] = useState(initialCheerList);
-  const [isOpen, open, close] = useBottomSheet();
+  const {
+    isOpen: isOpenBottomSheet,
+    open: openBottomSheet,
+    close: closeBottomSheet,
+  } = useBottomSheet();
+  const {
+    isOpen: isOpenModal,
+    open: openModal,
+    close: closeModal,
+  } = useModal();
+
   const { sliderRef } = useDragScroll();
 
   const handleClickCheerItem = (index: number) => {
@@ -76,6 +84,7 @@ export const DetailCheer = ({ data }: { data: RecordDetailType }) => {
   return (
     <>
       {/* TODO: 응원 조회 api 연동 및 모달 open 기능 구현 */}
+      {/* NOTE: 칭찬 미리보기 목록 */}
       <div className={slider.containerStyle} ref={sliderRef}>
         <div className={slider.wrapperStyle}>
           <CheerItem
@@ -114,42 +123,34 @@ export const DetailCheer = ({ data }: { data: RecordDetailType }) => {
             nickname="수영왕지영"
             size="small"
           />
-          <button className={slider.entireCheerButton}>응원 전체보기</button>
+          <button className={slider.entireCheerButton} onClick={openModal}>
+            응원 전체보기
+          </button>
         </div>
       </div>
-      <button className={cheerButtonWrapperStyle} onClick={open}>
+
+      {/* NOTE: 칭찬 FAB Button */}
+      <button className={cheerButtonWrapperStyle} onClick={openBottomSheet}>
         {data.member?.name}님에게 응원 보내기 👏
       </button>
-      <BottomSheet
+
+      {/* NOTE: 칭찬 모달 */}
+      <CheerModal
+        isOpen={isOpenModal}
+        onClose={closeModal}
+        title="8월 16일의 응원"
+        description="5"
+      />
+
+      {/* NOTE: 칭찬 바텀시트 */}
+      <CheerBottomSheet
         header={{ title: '응원 보내기' }}
-        isOpen={isOpen}
-        onClose={close}
-      >
-        <div className={tagContainerStyle}>
-          {cheerList.map((item, index) => (
-            <CheerItem
-              key={index}
-              onClick={() => handleClickCheerItem(index)}
-              {...item}
-            />
-          ))}
-        </div>
-        <div className={buttonContainerStyle}>
-          <Button
-            label="닫기"
-            variant="outlined"
-            size="large"
-            onClick={close}
-          />
-          <Button
-            label="보내기"
-            size="large"
-            variant="solid"
-            buttonType="primary"
-            onClick={handleClickSendCheer}
-          />
-        </div>
-      </BottomSheet>
+        isOpen={isOpenBottomSheet}
+        onClose={closeBottomSheet}
+        cheerList={cheerList}
+        onClickCheerItem={handleClickCheerItem}
+        onClickSendCheer={handleClickSendCheer}
+      />
     </>
   );
 };
@@ -197,17 +198,4 @@ const cheerButtonWrapperStyle = css({
   '@media (min-width: 600px)': {
     right: 'calc(50% - 300px + 20px);',
   },
-});
-
-const tagContainerStyle = flex({
-  wrap: 'wrap',
-  gap: '10px',
-  rowGap: '10px',
-  p: '8px 20px',
-});
-
-const buttonContainerStyle = grid({
-  gap: '10px',
-  p: '16px 20px 0 20px',
-  gridTemplateColumns: '1fr 1fr',
 });

--- a/hooks/index.ts
+++ b/hooks/index.ts
@@ -3,4 +3,5 @@ export * from './use-calendar-data';
 export * from './use-drag-scroll';
 export * from './use-intersection-observer';
 export * from './use-modal';
+export * from './use-prevent-body-scroll';
 export * from './use-timeline';

--- a/hooks/use-bottom-sheet.ts
+++ b/hooks/use-bottom-sheet.ts
@@ -4,6 +4,8 @@ import { useAtom } from 'jotai';
 
 import { bottomSheetAtom } from '@/store';
 
+import { usePreventBodyScroll } from './use-prevent-body-scroll';
+
 /**
  * @description 바텀시트를 조작하기 위해 사용합니다.
  *
@@ -14,6 +16,8 @@ import { bottomSheetAtom } from '@/store';
  */
 export const useBottomSheet = () => {
   const [isOpen, setIsOpen] = useAtom(bottomSheetAtom);
+
+  usePreventBodyScroll({ isOpen });
 
   const open = () => {
     setIsOpen(true);

--- a/hooks/use-dialog.ts
+++ b/hooks/use-dialog.ts
@@ -5,6 +5,8 @@ import { useAtom } from 'jotai';
 import { DialogProps } from '@/components/molecules';
 import { dialogAtom } from '@/store';
 
+import { usePreventBodyScroll } from './use-prevent-body-scroll';
+
 /**
  * @description Dialog를 조작하기 위해 사용합니다.
  *
@@ -26,6 +28,8 @@ import { dialogAtom } from '@/store';
 type DialogOptions = Omit<DialogProps, 'isOpen' | 'onClose'>;
 export const useDialog = () => {
   const [dialogState, setDialogState] = useAtom(dialogAtom);
+
+  usePreventBodyScroll({ isOpen: dialogState.isOpen });
 
   const dialog = (options: DialogOptions) => {
     setDialogState({

--- a/hooks/use-modal.ts
+++ b/hooks/use-modal.ts
@@ -4,6 +4,8 @@ import { useAtom } from 'jotai';
 
 import { modalAtom } from '@/store';
 
+import { usePreventBodyScroll } from './use-prevent-body-scroll';
+
 /**
  * @description 모달을 조작하기 위해 사용합니다.
  *
@@ -14,6 +16,8 @@ import { modalAtom } from '@/store';
  */
 export const useModal = () => {
   const [isOpen, setIsOpen] = useAtom(modalAtom);
+
+  usePreventBodyScroll({ isOpen });
 
   const open = () => {
     setIsOpen(true);

--- a/hooks/use-prevent-body-scroll.ts
+++ b/hooks/use-prevent-body-scroll.ts
@@ -1,0 +1,21 @@
+'use client';
+
+import { useEffect } from 'react';
+/**
+ * @description body element의 scroll을 막고 싶을 때 사용합니다.
+ *
+ * usePreventBodyScroll({ isOpen: false or true })
+ */
+export const usePreventBodyScroll = ({ isOpen }: { isOpen: boolean }) => {
+  useEffect(() => {
+    const body = document.querySelector('body');
+    if (!body) return;
+
+    if (isOpen) {
+      body.style.cssText =
+        'overflow:hidden; -webkit-overflow-scrolling: none; touch-action: none; overscroll-behavior: none; height: 100vh;';
+    } else {
+      body.removeAttribute('style');
+    }
+  }, [isOpen]);
+};


### PR DESCRIPTION
<!-- 작성 예시 -->
<!-- # 어떤 문제가 발생했나요? -->
<!-- - 간략한 문제 설명 -->
<!-- - 문제 관련 링크 등등 -->
<!-- Ex) React v18 version update에 후 테스트에서 에러가 발생합니다.
  라이브러리의 버전이 호환이 되지않아서 문제입니다. -->

<!-- # 어떻게 해결했나요? -->
<!-- - 동작 방식 등 수정힌 코드에 대한 설명 -->
<!-- Ex) 라이브러리의 버전을 업데이트하고, v18을 사용할 수 있도록 dev dependency로 설치해주었습니다. -->

<!-- # 이미지 첨부 (Option) -->
<!-- - 이번 PR의 동작 이해를 돕는 GIF나 이미지 파일 첨부! -->
<!-- - 만약 없다면, NA 혹은 비워둡시다~ -->

<!-- # 유의할 점 (Option) -->
<!-- - 추가적으로 고민중이거나 조언을 구하고 싶은 내용, 어떤 것을 중점으로 리뷰를 해줬으면 좋겠는지 등등 작성 -->
<!-- - 만약 없다면, NA 혹은 비워둡시다~ -->

## 🤔 어떤 문제가 발생했나요?

-

## 🎉 어떻게 해결했나요?

1. 응원하기 모달 내부 요소를 마크업합니다.
    -  최대 높이값을 가지며, 내부 요소의 크기에 따라 가변 높이를 가집니다.
    -  props, 이벤트 헨들러의 경우 추후 구현 예정입니다.
2. 응원 바텀시트를 별도의 컴포넌트로 분리합니다.
    - 분리된 응원 바텀시트 내부에서 추후 API 연동 작업을 거칠 예정입니다. 
    - 해당 요소는 다른 페이지에서도 사용될 수 있어, 추후 root component 디렉토리로 이동할 예정입니다.

> props, type 및 데이터 흐름은 API 연동 시에 변경될 수 있습니다.

### 📷 이미지 첨부 (Option)

- PC
<img width="599" alt="스크린샷 2024-08-17 오전 12 36 16" src="https://github.com/user-attachments/assets/f8adf4d4-0032-49ea-870f-b52745eee7cf">

- MO
<img width="372" alt="스크린샷 2024-08-17 오전 12 36 39" src="https://github.com/user-attachments/assets/a9fa8e14-0000-4590-93ab-46a1b3a30862">



### ⚠️ 유의할 점! (Option)

-

<!-- PR merge시 닫을 이슈가 있다면, 번호를 작성해주세요 -->
<!-- Ex) close #12 -->
