### PR TITLE
feat: usePreventBodyScroll hook 구현 및 적용

### DIFF
--- a/hooks/index.ts
+++ b/hooks/index.ts
@@ -3,4 +3,5 @@ export * from './use-calendar-data';
 export * from './use-drag-scroll';
 export * from './use-intersection-observer';
 export * from './use-modal';
+export * from './use-prevent-body-scroll';
 export * from './use-timeline';

--- a/hooks/use-bottom-sheet.ts
+++ b/hooks/use-bottom-sheet.ts
@@ -4,6 +4,8 @@ import { useAtom } from 'jotai';
 
 import { bottomSheetAtom } from '@/store';
 
+import { usePreventBodyScroll } from './use-prevent-body-scroll';
+
 /**
  * @description 바텀시트를 조작하기 위해 사용합니다.
  *
@@ -14,6 +16,8 @@ import { bottomSheetAtom } from '@/store';
  */
 export const useBottomSheet = () => {
   const [isOpen, setIsOpen] = useAtom(bottomSheetAtom);
+
+  usePreventBodyScroll({ isOpen });
 
   const open = () => {
     setIsOpen(true);

--- a/hooks/use-dialog.ts
+++ b/hooks/use-dialog.ts
@@ -5,6 +5,8 @@ import { useAtom } from 'jotai';
 import { DialogProps } from '@/components/molecules';
 import { dialogAtom } from '@/store';
 
+import { usePreventBodyScroll } from './use-prevent-body-scroll';
+
 /**
  * @description Dialog를 조작하기 위해 사용합니다.
  *
@@ -26,6 +28,8 @@ import { dialogAtom } from '@/store';
 type DialogOptions = Omit<DialogProps, 'isOpen' | 'onClose'>;
 export const useDialog = () => {
   const [dialogState, setDialogState] = useAtom(dialogAtom);
+
+  usePreventBodyScroll({ isOpen: dialogState.isOpen });
 
   const dialog = (options: DialogOptions) => {
     setDialogState({

--- a/hooks/use-modal.ts
+++ b/hooks/use-modal.ts
@@ -4,6 +4,8 @@ import { useAtom } from 'jotai';
 
 import { modalAtom } from '@/store';
 
+import { usePreventBodyScroll } from './use-prevent-body-scroll';
+
 /**
  * @description 모달을 조작하기 위해 사용합니다.
  *
@@ -14,6 +16,8 @@ import { modalAtom } from '@/store';
  */
 export const useModal = () => {
   const [isOpen, setIsOpen] = useAtom(modalAtom);
+
+  usePreventBodyScroll({ isOpen });
 
   const open = () => {
     setIsOpen(true);

--- a/hooks/use-prevent-body-scroll.ts
+++ b/hooks/use-prevent-body-scroll.ts
@@ -1,0 +1,21 @@
+'use client';
+
+import { useEffect } from 'react';
+/**
+ * @description body element의 scroll을 막고 싶을 때 사용합니다.
+ *
+ * usePreventBodyScroll({ isOpen: false or true })
+ */
+export const usePreventBodyScroll = ({ isOpen }: { isOpen: boolean }) => {
+  useEffect(() => {
+    const body = document.querySelector('body');
+    if (!body) return;
+
+    if (isOpen) {
+      body.style.cssText =
+        'overflow:hidden; -webkit-overflow-scrolling: none; touch-action: none; overscroll-behavior: none; height: 100vh;';
+    } else {
+      body.removeAttribute('style');
+    }
+  }, [isOpen]);
+};


### PR DESCRIPTION
<!-- 작성 예시 -->
<!-- # 어떤 문제가 발생했나요? -->
<!-- - 간략한 문제 설명 -->
<!-- - 문제 관련 링크 등등 -->
<!-- Ex) React v18 version update에 후 테스트에서 에러가 발생합니다.
  라이브러리의 버전이 호환이 되지않아서 문제입니다. -->

<!-- # 어떻게 해결했나요? -->
<!-- - 동작 방식 등 수정힌 코드에 대한 설명 -->
<!-- Ex) 라이브러리의 버전을 업데이트하고, v18을 사용할 수 있도록 dev dependency로 설치해주었습니다. -->

<!-- # 이미지 첨부 (Option) -->
<!-- - 이번 PR의 동작 이해를 돕는 GIF나 이미지 파일 첨부! -->
<!-- - 만약 없다면, NA 혹은 비워둡시다~ -->

<!-- # 유의할 점 (Option) -->
<!-- - 추가적으로 고민중이거나 조언을 구하고 싶은 내용, 어떤 것을 중점으로 리뷰를 해줬으면 좋겠는지 등등 작성 -->
<!-- - 만약 없다면, NA 혹은 비워둡시다~ -->

## 🤔 어떤 문제가 발생했나요?

- bottomSheet, dialog, modal 컴포넌트 하단에서 body element의 스크롤 기능이 유지되는 문제가 있습니다.

## 🎉 어떻게 해결했나요?

- body의 스크롤을 제어할 수 있는 `usePreventBodyScroll` hook을 구현합니다.
- bottomSheet, dialog, modal component의 `isOpen` 상태에 따라 스크롤이 막아지도록 훅을 적용합니다.

### 📷 이미지 첨부 (Option)


https://github.com/user-attachments/assets/93c67a65-ab3f-46fa-8b2f-0931ff25b47c



### ⚠️ 유의할 점! (Option)

-

<!-- PR merge시 닫을 이슈가 있다면, 번호를 작성해주세요 -->
<!-- Ex) close #12 -->
