### PR TITLE
fix: 기록 생성 시 PC 모드에서 사진이 틀 밖으로 나오는 현상 수정

### DIFF
--- a/features/record/components/organisms/photo-section.tsx
+++ b/features/record/components/organisms/photo-section.tsx
@@ -85,13 +85,14 @@ export function PhotoSection({ title, defaultImage }: PhotoSectionProps) {
             alt="오늘의 사진"
             fill
             sizes="100vw"
-            className="rounded-[10px]"
+            className={css({ borderRadius: '10px' })}
           />
           <DeletePhotoIcon
             className={css({
               position: 'absolute',
               top: '16px',
               right: '16px',
+              cursor: 'pointer',
             })}
             onClick={handleImageDeleteClick}
           />
@@ -114,8 +115,8 @@ const imageStyles = css({
   position: 'relative',
   width: 'calc(100vw - 40px)',
   height: 'calc(100vw - 40px)',
-  maxWidth: '600px',
-  maxHeight: '600px',
+  maxWidth: '560px',
+  maxHeight: '560px',
 });
 
 const titleStyles = css({


### PR DESCRIPTION
## 🤔 어떤 문제가 발생했나요?

- 기록 생성 시 PC 모드에서 사진이 틀 밖으로 나오는 현상이 있었습니다.

## 🎉 어떻게 해결했나요?

- 사진 layout에 padding을 고려한 maxWidth를 적용하였습니다.

### 📷 이미지 첨부 (Option)

<img width="681" alt="image" src="https://github.com/user-attachments/assets/2de9a46a-e338-43bf-ac13-13cd0eea0471">

### ⚠️ 유의할 점! (Option)

- NA
