### PR TITLE
fix: 수영 거리 기록 page-modal에 누락된 props 전달 및 스타일 수정

### DIFF
--- a/features/profile/components/organisms/profile-edit-form.tsx
+++ b/features/profile/components/organisms/profile-edit-form.tsx
@@ -13,6 +13,7 @@ interface ProfileEditFormProps {
   introduce?: string;
 }
 
+//Todo: 사진 선택 창 연결
 //Todo: api 연결
 //Todo: 한줄 소개 현재 글자 수 세는 UI 추가
 export function ProfileEditForm() {

--- a/features/profile/components/organisms/profile-edit-form.tsx
+++ b/features/profile/components/organisms/profile-edit-form.tsx
@@ -22,7 +22,6 @@ export function ProfileEditForm() {
 
   // eslint-disable-next-line @typescript-eslint/require-await
   const onSubmit: SubmitHandler<ProfileEditFormProps> = async (data) => {
-    //기록 수정 모드일 때
     console.log(data);
   };
 

--- a/features/record/components/atoms/select-element.tsx
+++ b/features/record/components/atoms/select-element.tsx
@@ -25,7 +25,7 @@ export function SelectElement({
   onChangeValue,
 }: SelectElementProps) {
   const handleListElementClick = () => {
-    onChangeValue?.(label);
+    if (!isSelected) onChangeValue?.(label);
     onCloseWrapper?.();
   };
   return (

--- a/features/record/components/organisms/distance-page-modal.tsx
+++ b/features/record/components/organisms/distance-page-modal.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useAtomValue } from 'jotai';
-import { useFormContext } from 'react-hook-form';
+import { useFormContext, useWatch } from 'react-hook-form';
 
 import { Button } from '@/components/atoms';
 import {
@@ -31,8 +31,13 @@ export function DistancePageModal({
   defaultTotalMeter,
   defaultTotalLap,
 }: DistancePageModalProps) {
-  const { getValues, setValue } = useFormContext();
+  const { setValue, control } = useFormContext();
   const pageModalState = useAtomValue(isDistancePageModalOpen);
+
+  const lane = useWatch({
+    control,
+    name: 'lane',
+  }) as number;
 
   const {
     pageModalRef,
@@ -45,7 +50,7 @@ export function DistancePageModal({
     buttonLabel,
     handlers,
   } = useDistancePageModal<HTMLDivElement>(
-    getValues('lane') as number,
+    lane,
     defaultStrokes,
     defaultTotalMeter,
     defaultTotalLap,

--- a/features/record/components/organisms/distance-page-modal.tsx
+++ b/features/record/components/organisms/distance-page-modal.tsx
@@ -12,6 +12,7 @@ import {
   TextField,
 } from '@/components/molecules';
 import { css } from '@/styled-system/css';
+import { flex } from '@/styled-system/patterns';
 
 import { useDistancePageModal } from '../../hooks';
 import { isDistancePageModalOpen } from '../../store';
@@ -144,7 +145,7 @@ export function DistancePageModal({
               />
             ))}
           </Tab>
-          <Tab type="assistive">
+          <div className={layout.assistiveTab}>
             {assistiveTabItems.map((tabItem) => (
               <TabItem
                 key={tabItem.text + assistiveTabIndex}
@@ -152,7 +153,7 @@ export function DistancePageModal({
                 {...tabItem}
               />
             ))}
-          </Tab>
+          </div>
         </section>
         <section className={layout.record}>
           {secondaryTabIndex === 0 && (
@@ -198,6 +199,9 @@ export function DistancePageModal({
 }
 
 const layout = {
+  assistiveTab: flex({
+    gap: '10px',
+  }),
   tab: css({
     width: '100%',
     marginTop: '16px',

--- a/features/record/components/organisms/form.tsx
+++ b/features/record/components/organisms/form.tsx
@@ -49,7 +49,6 @@ export function Form() {
   const date = searchParams.get('date');
   const isEditMode = Boolean(searchParams.get('memoryId'));
   const { data } = usePullEditMemory(Number(searchParams.get('memoryId')));
-  console.log(data);
   const [formSubInfo, setFormSubInfo] = useAtom(formSubInfoState);
   const methods = useForm<RecordRequestProps>({
     defaultValues: {

--- a/features/record/components/organisms/form.tsx
+++ b/features/record/components/organisms/form.tsx
@@ -49,6 +49,7 @@ export function Form() {
   const date = searchParams.get('date');
   const isEditMode = Boolean(searchParams.get('memoryId'));
   const { data } = usePullEditMemory(Number(searchParams.get('memoryId')));
+  console.log(data);
   const [formSubInfo, setFormSubInfo] = useAtom(formSubInfoState);
   const methods = useForm<RecordRequestProps>({
     defaultValues: {
@@ -318,7 +319,11 @@ export function Form() {
       </form>
       <LaneLengthBottomSheet title="레인 길이를 선택해주세요" />
       <PoolSearchPageModal title="어디서 수영했나요?" />
-      <DistancePageModal defaultStrokes={data?.data.strokes} />
+      <DistancePageModal
+        defaultStrokes={data?.data.strokes}
+        defaultTotalMeter={data?.data.totalMeter}
+        defaultTotalLap={data?.data.totalLap}
+      />
       <TimeBottomSheet />
     </FormProvider>
   );

--- a/features/record/components/organisms/lane-length-bottom-sheet.tsx
+++ b/features/record/components/organisms/lane-length-bottom-sheet.tsx
@@ -1,12 +1,14 @@
 'use client';
 
-import { useAtom } from 'jotai';
-import { useFormContext } from 'react-hook-form';
+import { useAtom, useAtomValue } from 'jotai';
+import { useFormContext, useWatch } from 'react-hook-form';
 
 import { BottomSheet } from '@/components/molecules';
 import { flex } from '@/styled-system/patterns';
 
+import { laneOptions } from '../../constants';
 import { isLaneLengthBottomSheetOpen } from '../../store';
+import { formSubInfoState } from '../../store/form-sub-info';
 import { SelectList } from '../molecules';
 
 interface LaneLengthBottomSheetProps {
@@ -17,17 +19,23 @@ interface LaneLengthBottomSheetProps {
  * @param title 레인 길이 선택 bottom-sheet 제목
  */
 export function LaneLengthBottomSheet({ title }: LaneLengthBottomSheetProps) {
-  const laneOptions = [
-    {
-      index: 0,
-      label: '25m',
-    },
-    { index: 1, label: '50m' },
-  ];
-  const { getValues, setValue } = useFormContext();
+  const { getValues, setValue, control } = useFormContext();
   const [isOpen, setIsOpen] = useAtom(isLaneLengthBottomSheetOpen);
+  const formSubInfo = useAtomValue(formSubInfoState);
+
+  const totalDistance = useWatch({
+    control,
+    name: 'totalDistance',
+  }) as string;
 
   const handleSelectLaneLength = (value: string) => {
+    if (formSubInfo.isDistanceLapModified && value === laneOptions[0].label)
+      setValue('totalDistance', Number(totalDistance?.slice(0, -1)) / 2 + 'm');
+    else if (
+      formSubInfo.isDistanceLapModified &&
+      value === laneOptions[1].label
+    )
+      setValue('totalDistance', Number(totalDistance?.slice(0, -1)) * 2 + 'm');
     setValue('laneMeter', value);
     setValue('lane', Number(value.slice(0, -1)));
   };

--- a/features/record/components/organisms/sub-info-text-fields.tsx
+++ b/features/record/components/organisms/sub-info-text-fields.tsx
@@ -16,7 +16,7 @@ export function SubInfoTextFields() {
         registerdFieldValue={
           useWatch({
             control,
-            name: 'heartRate' as string,
+            name: 'heartRate',
           }) as number
         }
         inputType="number"
@@ -30,7 +30,7 @@ export function SubInfoTextFields() {
           registerdFieldValue={
             useWatch({
               control,
-              name: 'paceMinutes' as string,
+              name: 'paceMinutes',
             }) as number
           }
           inputType="number"
@@ -43,7 +43,7 @@ export function SubInfoTextFields() {
           registerdFieldValue={
             useWatch({
               control,
-              name: 'paceSeconds' as string,
+              name: 'paceSeconds',
             }) as number
           }
           inputType="number"

--- a/features/record/constants/index.ts
+++ b/features/record/constants/index.ts
@@ -1,1 +1,2 @@
+export * from './lane';
 export * from './stroke-options';

--- a/features/record/constants/lane.ts
+++ b/features/record/constants/lane.ts
@@ -1,0 +1,7 @@
+export const laneOptions = [
+  {
+    index: 0,
+    label: '25m',
+  },
+  { index: 1, label: '50m' },
+];

--- a/features/record/hooks/use-distance-page-modal.tsx
+++ b/features/record/hooks/use-distance-page-modal.tsx
@@ -1,10 +1,11 @@
 'use client';
 
-import { useSetAtom } from 'jotai';
+import { useAtom, useSetAtom } from 'jotai';
 import { useEffect, useRef, useState } from 'react';
 
-import { strokeOptions } from '../constants';
+import { laneOptions, strokeOptions } from '../constants';
 import { isDistancePageModalOpen } from '../store';
+import { formSubInfoState } from '../store/form-sub-info';
 import { StrokeProps } from '../types';
 
 type tabIndex = 0 | 1;
@@ -16,6 +17,7 @@ export function useDistancePageModal<T>(
   defaultTotalMeter?: number,
   defaultTotalLap?: number,
 ) {
+  const [formSubInfo, setFormSubInfo] = useAtom(formSubInfoState);
   const pageModalRef = useRef<T>(null);
   const setPageModalState = useSetAtom(isDistancePageModalOpen);
   const [secondaryTabIndex, setSecondaryTabIndex] = useState<tabIndex>(0);
@@ -41,18 +43,22 @@ export function useDistancePageModal<T>(
       return;
     }
     if (assistiveTabIndex === 0) {
+      if (formSubInfo.isDistanceLapModified)
+        setFormSubInfo((prev) => ({ ...prev, isDistanceLapModified: false }));
       strokes.forEach((stroke) => {
         sum += stroke.meter;
       });
       setTotalStrokeDistance(sum);
     } else {
+      if (!formSubInfo.isDistanceLapModified)
+        setFormSubInfo((prev) => ({ ...prev, isDistanceLapModified: true }));
       strokes.forEach((stroke) => {
         sum += stroke.laps * lane * 2;
       });
       setTotalStrokeDistance(sum);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [strokes, lane]);
+  }, [strokes]);
 
   useEffect(() => {
     if (defaultStrokes) {
@@ -64,8 +70,14 @@ export function useDistancePageModal<T>(
         defaultStrokes.length === 1 &&
         defaultStrokes[0].name === '총바퀴'
       ) {
+        setFormSubInfo((prev) => ({ ...prev, isDistanceLapModified: true }));
         setTotalLaps(String(defaultTotalLap));
       } else {
+        if (
+          defaultStrokes.every((stroke) => stroke.laps) &&
+          !formSubInfo.isDistanceLapModified
+        )
+          setFormSubInfo((prev) => ({ ...prev, isDistanceLapModified: true }));
         defaultStrokes.forEach((strokes) => {
           setStrokes((prev) => [
             ...prev,
@@ -77,6 +89,20 @@ export function useDistancePageModal<T>(
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [defaultStrokes]);
+
+  useEffect(() => {
+    if (
+      formSubInfo.isDistanceLapModified &&
+      lane === Number(laneOptions[0].label.slice(0, -1))
+    )
+      setTotalStrokeDistance((prev) => prev / 2);
+    else if (
+      formSubInfo.isDistanceLapModified &&
+      lane === Number(laneOptions[1].label.slice(0, -1))
+    )
+      setTotalStrokeDistance((prev) => prev * 2);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [lane]);
 
   const onClosePageModal = () => {
     setPageModalState({ isOpen: false, jumpDirection: 'backward' });
@@ -92,6 +118,8 @@ export function useDistancePageModal<T>(
 
   //총거리를 m 입력했을 때, 다른 필드들에 값이 있다면 초기화
   const onChangeTotalMeter = (text: string) => {
+    if (formSubInfo.isDistanceLapModified)
+      setFormSubInfo((prev) => ({ ...prev, isDistanceLapModified: false }));
     totalLaps && setTotalLaps('');
     setTotalMeter(text);
     resetStrokesMeter();
@@ -100,6 +128,8 @@ export function useDistancePageModal<T>(
 
   //총거리를 바퀴단위로 입력했을 때, 다른 필드들에 값이 있다면 초기화
   const onChangeTotalLaps = (text: string) => {
+    if (!formSubInfo.isDistanceLapModified)
+      setFormSubInfo((prev) => ({ ...prev, isDistanceLapModified: true }));
     totalMeter && setTotalMeter('');
     setTotalLaps(text);
     setTotalStrokeDistance(text ? Number(text) * lane * 2 : 0);

--- a/features/record/hooks/use-distance-page-modal.tsx
+++ b/features/record/hooks/use-distance-page-modal.tsx
@@ -47,7 +47,7 @@ export function useDistancePageModal<T>(
       setTotalStrokeDistance(sum);
     } else {
       strokes.forEach((stroke) => {
-        sum += stroke.laps * lane;
+        sum += stroke.laps * lane * 2;
       });
       setTotalStrokeDistance(sum);
     }
@@ -102,7 +102,7 @@ export function useDistancePageModal<T>(
   const onChangeTotalLaps = (text: string) => {
     totalMeter && setTotalMeter('');
     setTotalLaps(text);
-    setTotalStrokeDistance(text ? Number(text) * lane : 0);
+    setTotalStrokeDistance(text ? Number(text) * lane * 2 : 0);
     resetStrokesMeter();
     resetStrokesLaps();
   };

--- a/features/record/store/form-sub-info.ts
+++ b/features/record/store/form-sub-info.ts
@@ -2,10 +2,12 @@ import { atom } from 'jotai';
 
 interface FormSubInfoProps {
   imageFiles: File[];
+  isDistanceLapModified?: boolean;
 }
 
 const initialState = {
   imageFiles: [],
+  isDistanceLapModified: false,
 };
 
 export const formSubInfoState = atom<FormSubInfoProps>(initialState);


### PR DESCRIPTION
## 🤔 어떤 문제가 발생했나요?

- 외부에서 totalLaps와 totalMeter를 수영 거리 기록 page-modal에 넘겨주는 부분이 누락되었습니다.

- page-modal에서 assistive tab item 관련 스타일이 깨졌습니다.

- 바퀴 수로 기록 시, 총 거리를 계산하는 로직이 바뀌었습니다(1바퀴 = lane * 2).

## 🎉 어떻게 해결했나요?

- totalLaps와 totalMeter prop을 전달해주었습니다.

- assistive tab의 layout 스타일을 수정하였습니다.

- 계산 로직을 수정하였습니다.

### 📷 이미지 첨부 (Option)

- assistive tab 스타일

<img width="282" alt="image" src="https://github.com/user-attachments/assets/dfa63e9c-1918-4301-8f2d-edbe8e2b2a3f">

- 바퀴 수로 입력 시 1바퀴 당 lane * 2 미터로 계산

https://github.com/user-attachments/assets/b49b7de9-17b3-4e28-b97b-eac1afc49109

### ⚠️ 유의할 점! (Option)

- NA
