### PR TITLE
fix: 수영 거리를 바퀴 수로 입력 후, 추후 lane을 수정할 때 총 거리가 수정되지 않는 버그 해결

### DIFF
--- a/features/record/components/atoms/select-element.tsx
+++ b/features/record/components/atoms/select-element.tsx
@@ -25,7 +25,7 @@ export function SelectElement({
   onChangeValue,
 }: SelectElementProps) {
   const handleListElementClick = () => {
-    onChangeValue?.(label);
+    if (!isSelected) onChangeValue?.(label);
     onCloseWrapper?.();
   };
   return (

--- a/features/record/components/organisms/distance-page-modal.tsx
+++ b/features/record/components/organisms/distance-page-modal.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useAtomValue } from 'jotai';
-import { useFormContext } from 'react-hook-form';
+import { useFormContext, useWatch } from 'react-hook-form';
 
 import { Button } from '@/components/atoms';
 import {
@@ -31,8 +31,13 @@ export function DistancePageModal({
   defaultTotalMeter,
   defaultTotalLap,
 }: DistancePageModalProps) {
-  const { getValues, setValue } = useFormContext();
+  const { setValue, control } = useFormContext();
   const pageModalState = useAtomValue(isDistancePageModalOpen);
+
+  const lane = useWatch({
+    control,
+    name: 'lane',
+  }) as number;
 
   const {
     pageModalRef,
@@ -45,7 +50,7 @@ export function DistancePageModal({
     buttonLabel,
     handlers,
   } = useDistancePageModal<HTMLDivElement>(
-    getValues('lane') as number,
+    lane,
     defaultStrokes,
     defaultTotalMeter,
     defaultTotalLap,

--- a/features/record/components/organisms/form.tsx
+++ b/features/record/components/organisms/form.tsx
@@ -49,7 +49,6 @@ export function Form() {
   const date = searchParams.get('date');
   const isEditMode = Boolean(searchParams.get('memoryId'));
   const { data } = usePullEditMemory(Number(searchParams.get('memoryId')));
-  console.log(data);
   const [formSubInfo, setFormSubInfo] = useAtom(formSubInfoState);
   const methods = useForm<RecordRequestProps>({
     defaultValues: {

--- a/features/record/components/organisms/lane-length-bottom-sheet.tsx
+++ b/features/record/components/organisms/lane-length-bottom-sheet.tsx
@@ -1,12 +1,14 @@
 'use client';
 
-import { useAtom } from 'jotai';
-import { useFormContext } from 'react-hook-form';
+import { useAtom, useAtomValue } from 'jotai';
+import { useFormContext, useWatch } from 'react-hook-form';
 
 import { BottomSheet } from '@/components/molecules';
 import { flex } from '@/styled-system/patterns';
 
+import { laneOptions } from '../../constants';
 import { isLaneLengthBottomSheetOpen } from '../../store';
+import { formSubInfoState } from '../../store/form-sub-info';
 import { SelectList } from '../molecules';
 
 interface LaneLengthBottomSheetProps {
@@ -17,17 +19,23 @@ interface LaneLengthBottomSheetProps {
  * @param title 레인 길이 선택 bottom-sheet 제목
  */
 export function LaneLengthBottomSheet({ title }: LaneLengthBottomSheetProps) {
-  const laneOptions = [
-    {
-      index: 0,
-      label: '25m',
-    },
-    { index: 1, label: '50m' },
-  ];
-  const { getValues, setValue } = useFormContext();
+  const { getValues, setValue, control } = useFormContext();
   const [isOpen, setIsOpen] = useAtom(isLaneLengthBottomSheetOpen);
+  const formSubInfo = useAtomValue(formSubInfoState);
+
+  const totalDistance = useWatch({
+    control,
+    name: 'totalDistance',
+  }) as string;
 
   const handleSelectLaneLength = (value: string) => {
+    if (formSubInfo.isDistanceLapModified && value === laneOptions[0].label)
+      setValue('totalDistance', Number(totalDistance?.slice(0, -1)) / 2 + 'm');
+    else if (
+      formSubInfo.isDistanceLapModified &&
+      value === laneOptions[1].label
+    )
+      setValue('totalDistance', Number(totalDistance?.slice(0, -1)) * 2 + 'm');
     setValue('laneMeter', value);
     setValue('lane', Number(value.slice(0, -1)));
   };

--- a/features/record/components/organisms/sub-info-text-fields.tsx
+++ b/features/record/components/organisms/sub-info-text-fields.tsx
@@ -16,7 +16,7 @@ export function SubInfoTextFields() {
         registerdFieldValue={
           useWatch({
             control,
-            name: 'heartRate' as string,
+            name: 'heartRate',
           }) as number
         }
         inputType="number"
@@ -30,7 +30,7 @@ export function SubInfoTextFields() {
           registerdFieldValue={
             useWatch({
               control,
-              name: 'paceMinutes' as string,
+              name: 'paceMinutes',
             }) as number
           }
           inputType="number"
@@ -43,7 +43,7 @@ export function SubInfoTextFields() {
           registerdFieldValue={
             useWatch({
               control,
-              name: 'paceSeconds' as string,
+              name: 'paceSeconds',
             }) as number
           }
           inputType="number"

--- a/features/record/constants/index.ts
+++ b/features/record/constants/index.ts
@@ -1,1 +1,2 @@
+export * from './lane';
 export * from './stroke-options';

--- a/features/record/constants/lane.ts
+++ b/features/record/constants/lane.ts
@@ -1,0 +1,7 @@
+export const laneOptions = [
+  {
+    index: 0,
+    label: '25m',
+  },
+  { index: 1, label: '50m' },
+];

--- a/features/record/hooks/use-distance-page-modal.tsx
+++ b/features/record/hooks/use-distance-page-modal.tsx
@@ -1,10 +1,11 @@
 'use client';
 
-import { useSetAtom } from 'jotai';
+import { useAtom, useSetAtom } from 'jotai';
 import { useEffect, useRef, useState } from 'react';
 
-import { strokeOptions } from '../constants';
+import { laneOptions, strokeOptions } from '../constants';
 import { isDistancePageModalOpen } from '../store';
+import { formSubInfoState } from '../store/form-sub-info';
 import { StrokeProps } from '../types';
 
 type tabIndex = 0 | 1;
@@ -16,6 +17,7 @@ export function useDistancePageModal<T>(
   defaultTotalMeter?: number,
   defaultTotalLap?: number,
 ) {
+  const [formSubInfo, setFormSubInfo] = useAtom(formSubInfoState);
   const pageModalRef = useRef<T>(null);
   const setPageModalState = useSetAtom(isDistancePageModalOpen);
   const [secondaryTabIndex, setSecondaryTabIndex] = useState<tabIndex>(0);
@@ -41,18 +43,22 @@ export function useDistancePageModal<T>(
       return;
     }
     if (assistiveTabIndex === 0) {
+      if (formSubInfo.isDistanceLapModified)
+        setFormSubInfo((prev) => ({ ...prev, isDistanceLapModified: false }));
       strokes.forEach((stroke) => {
         sum += stroke.meter;
       });
       setTotalStrokeDistance(sum);
     } else {
+      if (!formSubInfo.isDistanceLapModified)
+        setFormSubInfo((prev) => ({ ...prev, isDistanceLapModified: true }));
       strokes.forEach((stroke) => {
         sum += stroke.laps * lane * 2;
       });
       setTotalStrokeDistance(sum);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [strokes, lane]);
+  }, [strokes]);
 
   useEffect(() => {
     if (defaultStrokes) {
@@ -64,8 +70,14 @@ export function useDistancePageModal<T>(
         defaultStrokes.length === 1 &&
         defaultStrokes[0].name === '총바퀴'
       ) {
+        setFormSubInfo((prev) => ({ ...prev, isDistanceLapModified: true }));
         setTotalLaps(String(defaultTotalLap));
       } else {
+        if (
+          defaultStrokes.every((stroke) => stroke.laps) &&
+          !formSubInfo.isDistanceLapModified
+        )
+          setFormSubInfo((prev) => ({ ...prev, isDistanceLapModified: true }));
         defaultStrokes.forEach((strokes) => {
           setStrokes((prev) => [
             ...prev,
@@ -77,6 +89,20 @@ export function useDistancePageModal<T>(
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [defaultStrokes]);
+
+  useEffect(() => {
+    if (
+      formSubInfo.isDistanceLapModified &&
+      lane === Number(laneOptions[0].label.slice(0, -1))
+    )
+      setTotalStrokeDistance((prev) => prev / 2);
+    else if (
+      formSubInfo.isDistanceLapModified &&
+      lane === Number(laneOptions[1].label.slice(0, -1))
+    )
+      setTotalStrokeDistance((prev) => prev * 2);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [lane]);
 
   const onClosePageModal = () => {
     setPageModalState({ isOpen: false, jumpDirection: 'backward' });
@@ -92,6 +118,8 @@ export function useDistancePageModal<T>(
 
   //총거리를 m 입력했을 때, 다른 필드들에 값이 있다면 초기화
   const onChangeTotalMeter = (text: string) => {
+    if (formSubInfo.isDistanceLapModified)
+      setFormSubInfo((prev) => ({ ...prev, isDistanceLapModified: false }));
     totalLaps && setTotalLaps('');
     setTotalMeter(text);
     resetStrokesMeter();
@@ -100,6 +128,8 @@ export function useDistancePageModal<T>(
 
   //총거리를 바퀴단위로 입력했을 때, 다른 필드들에 값이 있다면 초기화
   const onChangeTotalLaps = (text: string) => {
+    if (!formSubInfo.isDistanceLapModified)
+      setFormSubInfo((prev) => ({ ...prev, isDistanceLapModified: true }));
     totalMeter && setTotalMeter('');
     setTotalLaps(text);
     setTotalStrokeDistance(text ? Number(text) * lane * 2 : 0);

--- a/features/record/store/form-sub-info.ts
+++ b/features/record/store/form-sub-info.ts
@@ -2,10 +2,12 @@ import { atom } from 'jotai';
 
 interface FormSubInfoProps {
   imageFiles: File[];
+  isDistanceLapModified?: boolean;
 }
 
 const initialState = {
   imageFiles: [],
+  isDistanceLapModified: false,
 };
 
 export const formSubInfoState = atom<FormSubInfoProps>(initialState);


### PR DESCRIPTION
## 🤔 어떤 문제가 발생했나요?

- 수영 거리를 바퀴 수로 입력한 후, lane을 바꾸면 수영 거리가 수정되지 않았습니다.

## 🎉 어떻게 해결했나요?

- 바퀴 수의 수정 상태를 파악하기 위한 상태 하나를 추가한 후, 바퀴 수가 수정된 상태에서 lane이 변경될 시 현재 총 거리를 수정하는 로직을 useEffect 훅으로 구현하였습니다.

- 바퀴 수 입력 후 lane 25m -> 50m로 수정 -> 총 거리 * 2
- 바퀴 수 입력 후 lane 50m -> 25m로 수정 -> 총 거리 / 2

### 📷 이미지 첨부 (Option)

- 총 바퀴 수 입력 후 lane 25m -> 50m로 수정

https://github.com/user-attachments/assets/08eed980-f474-46a6-915c-04cc64d6db0d

- 총 바퀴 수 입력 후 lane 50m -> 25m로 수정

https://github.com/user-attachments/assets/abd7c9ed-5d25-48da-9e3c-5641262056ce

- 영법별 바퀴 수로 입력 후 lane 25m -> 50m로 수정

https://github.com/user-attachments/assets/b8946289-90d0-49e5-b76a-284258c30fc2

- 영법별 바퀴 수로 입력 후 lane 50m -> 25m로 수정

https://github.com/user-attachments/assets/10efbba7-606a-44b5-9afb-bf92ee66a17a

- 미터 수로 입력 후 lane 수정 (총 거리 변화 없음)

https://github.com/user-attachments/assets/111db717-ec29-4540-8e42-464a03763627'

- 바퀴 수 입력 후 같은 lane 클릭 (총 거리 변화 없음)

https://github.com/user-attachments/assets/711f0605-8f47-49f6-b778-00046fccfb96

### ⚠️ 유의할 점! (Option)

- NA