### PR TITLE
chore: 수영 거리 기록 로직과 관련된 routing 수정

### DIFF
--- a/app/record/success/page.tsx
+++ b/app/record/success/page.tsx
@@ -34,6 +34,7 @@ export default function RecordSuccessPage({
       <Link
         href={`/record-detail/${searchParams.memoryId}`}
         className={buttonStyles}
+        replace
       >
         <Button
           buttonType="primary"

--- a/features/record/components/organisms/form.tsx
+++ b/features/record/components/organisms/form.tsx
@@ -166,7 +166,7 @@ export function Form() {
           memoryId: Number(searchParams.get('memoryId')),
         });
         if (memoryRes.status === 200)
-          router.push(
+          router.replace(
             `/record/success?editMode=true&memoryId=${Number(searchParams.get('memoryId'))}`,
           );
       }
@@ -177,7 +177,7 @@ export function Form() {
           memoryId: Number(searchParams.get('memoryId')),
         });
         if (memoryEditRes)
-          router.push(
+          router.replace(
             `/record/success?editMode=true&memoryId=${Number(searchParams.get('memoryId'))}`,
           );
       }
@@ -199,7 +199,7 @@ export function Form() {
           imageIdList: [getImagePresignedUrlRes.data[0].imageId],
         });
         if (memoryRes.status === 200)
-          router.push(
+          router.replace(
             `/record/success?rank=${memoryRes.data.rank}&memoryId=${memoryRes.data.memoryId}&month=${memoryRes.data.month}`,
           );
       }
@@ -207,7 +207,7 @@ export function Form() {
       else {
         const memoryRes = await memory(submitData);
         if (memoryRes.status === 200)
-          router.push(
+          router.replace(
             `/record/success?rank=${memoryRes.data.rank}&memoryId=${memoryRes.data.memoryId}&month=${memoryRes.data.month}`,
           );
       }


### PR DESCRIPTION
## 🤔 어떤 문제가 발생했나요?

- 수영 거리 기록 완료 후, 상세 페이지에서 뒤로가기를 누르면 다시 기록 완료 페이지가 나타났습니다.

## 🎉 어떻게 해결했나요?

- replace를 통한 특정 route를 history에 쌓이지 않도록 처리하였습니다.

### 📷 이미지 첨부 (Option)

https://github.com/user-attachments/assets/17402805-aa3a-41ea-ba45-8d74148e0268

### ⚠️ 유의할 점! (Option)

- 아이디어를 내준 지영님 감사합니다:)

- Todo: 기록된 달력 날짜 클릭 -> 상세 페이지의 수정 버튼 클릭 -> 기록 페이지에서 기록 수정 완료 후 다시 상세 페이지로 접근 -> 뒤로가기를 두번 눌러야 홈으로 이동되는 로직 처리 필요

- 기록 상세 페이지에서 수정 버튼 클릭 시, 기록 페이지로 넘어갈 때도 replace를 처리하면 해결되지만 / 해당 방식으로 처리하면 홈 -> 기록 상세 페이지 -> 기록 페이지에서 뒤로가기를 누르면 상세 페이지로 이동되는게 아니라 바로 홈으로 이동되게 되어서 이 로직이 괜찮을까 의논이 필요할 것 같습니다.
