### PR TITLE
fix: 사파리에서 로컬 환경일 때 소셜 로그인 진행 시 쿠키가 심기지 않는 버그를 수정했습니다.

### DIFF
--- a/apis/server-cookie.ts
+++ b/apis/server-cookie.ts
@@ -5,6 +5,8 @@ export interface TokenData {
   refreshToken: string;
 }
 
+const isProduction = process.env.NODE_ENV === 'production';
+
 // 쿠키 세팅
 export function setAuthCookies(tokenData: TokenData): void {
   const cookieStore = cookies();
@@ -13,14 +15,14 @@ export function setAuthCookies(tokenData: TokenData): void {
   cookieStore.set('accessToken', tokenData.accessToken, {
     maxAge: 3600, // 1시간
     httpOnly: true,
-    secure: true,
+    secure: isProduction,
   });
 
   // 리프레시 토큰
   cookieStore.set('refreshToken', tokenData.refreshToken, {
     maxAge: 7 * 24 * 3600, // 7일
     httpOnly: true,
-    secure: true,
+    secure: isProduction,
   });
 }
 


### PR DESCRIPTION
<!-- 작성 예시 -->
<!-- # 어떤 문제가 발생했나요? -->
<!-- - 간략한 문제 설명 -->
<!-- - 문제 관련 링크 등등 -->
<!-- Ex) React v18 version update에 후 테스트에서 에러가 발생합니다.
  라이브러리의 버전이 호환이 되지않아서 문제입니다. -->

<!-- # 어떻게 해결했나요? -->
<!-- - 동작 방식 등 수정힌 코드에 대한 설명 -->
<!-- Ex) 라이브러리의 버전을 업데이트하고, v18을 사용할 수 있도록 dev dependency로 설치해주었습니다. -->

<!-- # 이미지 첨부 (Option) -->
<!-- - 이번 PR의 동작 이해를 돕는 GIF나 이미지 파일 첨부! -->
<!-- - 만약 없다면, NA 혹은 비워둡시다~ -->

<!-- # 유의할 점 (Option) -->
<!-- - 추가적으로 고민중이거나 조언을 구하고 싶은 내용, 어떤 것을 중점으로 리뷰를 해줬으면 좋겠는지 등등 작성 -->
<!-- - 만약 없다면, NA 혹은 비워둡시다~ -->

## 🤔 어떤 문제가 발생했나요?

- 사파리에서 로컬 환경일 때 소셜 로그인 진행 시 쿠키가 심기지 않는 이슈가 있었습니다.

## 🎉 어떻게 해결했나요?

- 원칙 상 secure는 https에서만 저장이 되어야 하지만 개발 편의 상 localhost에서는 예외로 취급하는 것으로 알고 있습니다. 
- 하지만 갑자기 진행이 되지 않아 개발 환경인지 프로덕트 환경인지 확인하여 secure 값을 불리언으로 주는 방식으로 수정했습니다. ([참고](https://shanepark.tistory.com/454#google_vignette))

### 📷 이미지 첨부 (Option)

-

### ⚠️ 유의할 점! (Option)

-

<!-- PR merge시 닫을 이슈가 있다면, 번호를 작성해주세요 -->
<!-- Ex) close #12 -->
