### PR TITLE
fix: 기록 페이지에서 끝 시간 select-text-field의 label 제거

### DIFF
--- a/features/record/components/organisms/form.tsx
+++ b/features/record/components/organisms/form.tsx
@@ -243,10 +243,11 @@ export function Form() {
             <span className={css({ fontSize: '30px' })}>-</span>
             <SelectTextField
               fieldName="endTime"
-              isRequired
-              label="수영 시간"
               placeholder="00:00"
-              wrapperClassName={timeStyles.field}
+              wrapperClassName={cx(
+                timeStyles.field,
+                css({ marginTop: '24px' }),
+              )}
               onClick={() =>
                 setTimeBottomSheetState((prev) => ({
                   ...prev,


### PR DESCRIPTION
## 🤔 어떤 문제가 발생했나요?

- 기록 페이지에서 끝 시간을 고르는 select-text-field에 label이 있었습니다.

## 🎉 어떻게 해결했나요?

- label을 제거해주었습니다. 추가로 label이 없어 올라가는 text-field의 위치를 marginTop 속성으로 조정해 주었습니다.

### 📷 이미지 첨부 (Option)

<img width="222" alt="image" src="https://github.com/user-attachments/assets/67ff2feb-3e96-4b2a-a8a0-ef0341aecd54">

- before & after

<img width="289" alt="image" src="https://github.com/user-attachments/assets/fd3f2394-7a27-42f7-86d3-bbed4a148295">

<img width="280" alt="image" src="https://github.com/user-attachments/assets/ed885d4c-261a-470b-a901-b9dbf024776b">

### ⚠️ 유의할 점! (Option)

- NA
