### PR TITLE
chore: 가록 페이지에서 select-text-field의 cursor를 pointer로 설정

### DIFF
--- a/components/molecules/text-field/select-text-field.tsx
+++ b/components/molecules/text-field/select-text-field.tsx
@@ -57,7 +57,11 @@ export function SelectTextField({
             {...field}
             readOnly
             placeholder={placeholder}
-            className={cx(css(inputStyles), className)}
+            className={cx(
+              css(inputStyles),
+              css({ cursor: 'pointer' }),
+              className,
+            )}
             onClick={onClick}
             onChange={field.onChange}
           />


### PR DESCRIPTION
## 🤔 어떤 문제가 발생했나요?

- PC에서 select-text-field의 input에 마우스를 올리면 커서가 입력 모드로 보여졌습니다.

## 🎉 어떻게 해결했나요?

- select-text-field 컴포넌트의 input 태그에 cursor:"pointer" 속성을 적용하였습니다.

### 📷 이미지 첨부 (Option)

<img width="214" alt="image" src="https://github.com/user-attachments/assets/a43c5e03-e101-4692-81ce-342f46a51599">

### ⚠️ 유의할 점! (Option)

- NA
