### PR TITLE
fix: 버튼의 아이콘 props type을 reactNode로 수정했습니다.

### DIFF
--- a/components/atoms/button/button.stories.tsx
+++ b/components/atoms/button/button.stories.tsx
@@ -2,6 +2,8 @@ import type { Meta, StoryObj } from '@storybook/react';
 
 import { css } from '@/styled-system/css';
 
+import BadgeIcon from '../icons/badge-icon';
+import StatisticsIcon from '../icons/statistics-icon';
 import { Button } from './button';
 
 const meta: Meta<typeof Button> = {
@@ -41,10 +43,16 @@ const meta: Meta<typeof Button> = {
       control: 'text',
     },
     leftIconSrc: {
-      control: 'text',
+      control: 'object',
+      table: {
+        disable: true,
+      },
     },
     rightIconSrc: {
-      control: 'text',
+      control: 'object',
+      table: {
+        disable: true,
+      },
     },
     className: {
       control: 'text',
@@ -75,5 +83,27 @@ export const text: Story = {
   args: {
     ...Default.args,
     variant: 'text',
+  },
+};
+
+export const leftIcon: Story = {
+  args: {
+    ...Default.args,
+    leftIconSrc: <BadgeIcon />,
+  },
+};
+
+export const rightIcon: Story = {
+  args: {
+    ...Default.args,
+    rightIconSrc: <StatisticsIcon />,
+  },
+};
+
+export const bothIcon: Story = {
+  args: {
+    ...Default.args,
+    leftIconSrc: <BadgeIcon />,
+    rightIconSrc: <StatisticsIcon />,
   },
 };

--- a/components/atoms/button/button.tsx
+++ b/components/atoms/button/button.tsx
@@ -1,5 +1,3 @@
-import Image from 'next/image';
-
 import { css, cx } from '@/styled-system/css';
 import { flex } from '@/styled-system/patterns';
 
@@ -154,11 +152,17 @@ export const Button = ({
     }),
   );
 
-  const iconSize = size === 'large' ? 20 : size === 'medium' ? 18 : 16;
+  const iconSizeMap = {
+    large: '24px',
+    medium: '20px',
+    small: '16px',
+  };
+
+  const iconSize = iconSizeMap[size];
 
   const iconWrapperStyles = flex({
-    width: `${iconSize}px`,
-    height: `${iconSize}px`,
+    width: iconSize,
+    height: iconSize,
     alignItems: 'center',
     justifyContent: 'center',
   });
@@ -168,27 +172,11 @@ export const Button = ({
       {(leftIconSrc || isLoading) && (
         <div className={iconWrapperStyles}>
           {isLoading && <LoadingButtonIcon />}
-          {leftIconSrc && (
-            <Image
-              src={leftIconSrc}
-              alt="left icon"
-              width={iconSize}
-              height={iconSize}
-            />
-          )}
+          {!isLoading && leftIconSrc}
         </div>
       )}
       {label}
-      {rightIconSrc && (
-        <div className={iconWrapperStyles}>
-          <Image
-            src={rightIconSrc}
-            alt="right icon"
-            width={iconSize}
-            height={iconSize}
-          />
-        </div>
-      )}
+      {rightIconSrc && <div className={iconWrapperStyles}>{rightIconSrc}</div>}
     </button>
   );
 };

--- a/components/atoms/button/type.ts
+++ b/components/atoms/button/type.ts
@@ -1,3 +1,5 @@
+import { ReactNode } from 'react';
+
 export interface ButtonProps {
   disabled?: boolean;
   label: string;
@@ -6,8 +8,8 @@ export interface ButtonProps {
   variant?: 'solid' | 'outlined' | 'text';
   buttonType?: 'primary' | 'secondary' | 'assistive';
   type?: 'button' | 'reset' | 'submit';
-  leftIconSrc?: string;
-  rightIconSrc?: string;
+  leftIconSrc?: ReactNode;
+  rightIconSrc?: ReactNode;
   onClick?: () => void;
   className?: string;
   isLoading?: boolean;


### PR DESCRIPTION
<!-- 작성 예시 -->
<!-- # 어떤 문제가 발생했나요? -->
<!-- - 간략한 문제 설명 -->
<!-- - 문제 관련 링크 등등 -->
<!-- Ex) React v18 version update에 후 테스트에서 에러가 발생합니다.
  라이브러리의 버전이 호환이 되지않아서 문제입니다. -->

<!-- # 어떻게 해결했나요? -->
<!-- - 동작 방식 등 수정힌 코드에 대한 설명 -->
<!-- Ex) 라이브러리의 버전을 업데이트하고, v18을 사용할 수 있도록 dev dependency로 설치해주었습니다. -->

<!-- # 이미지 첨부 (Option) -->
<!-- - 이번 PR의 동작 이해를 돕는 GIF나 이미지 파일 첨부! -->
<!-- - 만약 없다면, NA 혹은 비워둡시다~ -->

<!-- # 유의할 점 (Option) -->
<!-- - 추가적으로 고민중이거나 조언을 구하고 싶은 내용, 어떤 것을 중점으로 리뷰를 해줬으면 좋겠는지 등등 작성 -->
<!-- - 만약 없다면, NA 혹은 비워둡시다~ -->

## 🤔 어떤 문제가 발생했나요?

- 버튼 컴포넌트 사용 시, 아이콘은 next/image를 사용하여 src가 string으로 들어가야 하지만 현재 우리 팀은 아이콘을 컴포넌트로 만들고 있어 타입이 일치하지 않습니다.

## 🎉 어떻게 해결했나요?

- 아이콘의 type을 string이 아닌 ReactNode로 수정하고, Button 컴포넌트 내에서도 Image가 아닌 div 태그로 랩핑했습니다.
- 아이콘 사이즈에 대한 스타일링도 기존 스타일링과 유사하게 Map으로 수정하였습니다. 

### 📷 이미지 첨부 (Option)

[페이지에서 사용할 때]
<img width="278" alt="image" src="https://github.com/user-attachments/assets/e229e007-57fc-4413-8100-e35e8ae314bf">

### ⚠️ 유의할 점! (Option)

- 스토리북에서는 컴포넌트를 아이콘으로 넣다 보니 테스트할 수 없습니다. (하는 방법을 찾지 못했는데 아신다면 알려주시면 감사하겠습니다!)
- 그래서 스토리를 3가지 따로 만들어두어서 여기서 다른 props로 테스트하실 수 있습니다.

![image](https://github.com/user-attachments/assets/9680a56c-d976-4623-8e33-c264a738b2f8)


<!-- PR merge시 닫을 이슈가 있다면, 번호를 작성해주세요 -->
<!-- Ex) close #12 -->
