### PR TITLE
chore: header-bar 컴포넌트 left-content도 외부에서 ReactNode 타입으로 주입할 수 있게끔 구현

### DIFF
--- a/app/alarm/page.tsx
+++ b/app/alarm/page.tsx
@@ -1,6 +1,16 @@
+import dynamic from 'next/dynamic';
+
+import { LeftArrowIcon } from '@/components/atoms';
 import { HeaderBar } from '@/components/molecules';
 import { AlarmElementProps, NoAlarm } from '@/features/alarm';
 import { AlarmList } from '@/features/alarm/components/organisms/alarm-list';
+const DynamicBackButton = dynamic(
+  () => import('@/components/molecules').then(({ BackButton }) => BackButton),
+  {
+    ssr: false,
+    loading: () => <LeftArrowIcon />,
+  },
+);
 
 //Todo: 알람 불러오는 Api 연결
 export default function AlarmPage() {
@@ -51,7 +61,9 @@ export default function AlarmPage() {
   return (
     <>
       <HeaderBar>
-        <HeaderBar.BackButton />
+        <HeaderBar.LeftContent>
+          <DynamicBackButton />
+        </HeaderBar.LeftContent>
         <HeaderBar.Title>알림</HeaderBar.Title>
       </HeaderBar>
       {!dummyAlarms ? (

--- a/app/join/gender/page.tsx
+++ b/app/join/gender/page.tsx
@@ -1,21 +1,13 @@
 /* eslint-disable @typescript-eslint/no-misused-promises */
 'use client';
 
-import dynamic from 'next/dynamic';
 import { useRouter } from 'next/navigation';
 import { useState } from 'react';
 
-import { Button, LeftArrowIcon } from '@/components/atoms';
-import { HeaderBar } from '@/components/molecules';
+import { Button } from '@/components/atoms';
+import { BackButton, HeaderBar } from '@/components/molecules';
 import { css, cva } from '@/styled-system/css';
 import { flex } from '@/styled-system/patterns';
-const DynamicBackButton = dynamic(
-  () => import('@/components/molecules').then(({ BackButton }) => BackButton),
-  {
-    ssr: false,
-    loading: () => <LeftArrowIcon />,
-  },
-);
 
 export interface GenderData {
   gender: 'W' | 'M';
@@ -75,7 +67,7 @@ export default function JoinPage() {
     <div>
       <HeaderBar className={headerStyles}>
         <HeaderBar.LeftContent>
-          <DynamicBackButton />
+          <BackButton />
         </HeaderBar.LeftContent>
       </HeaderBar>
       <div className={pageStyles}>

--- a/app/join/gender/page.tsx
+++ b/app/join/gender/page.tsx
@@ -1,13 +1,21 @@
 /* eslint-disable @typescript-eslint/no-misused-promises */
 'use client';
 
+import dynamic from 'next/dynamic';
 import { useRouter } from 'next/navigation';
 import { useState } from 'react';
 
-import { Button } from '@/components/atoms';
+import { Button, LeftArrowIcon } from '@/components/atoms';
 import { HeaderBar } from '@/components/molecules';
 import { css, cva } from '@/styled-system/css';
 import { flex } from '@/styled-system/patterns';
+const DynamicBackButton = dynamic(
+  () => import('@/components/molecules').then(({ BackButton }) => BackButton),
+  {
+    ssr: false,
+    loading: () => <LeftArrowIcon />,
+  },
+);
 
 export interface GenderData {
   gender: 'W' | 'M';
@@ -66,7 +74,9 @@ export default function JoinPage() {
   return (
     <div>
       <HeaderBar className={headerStyles}>
-        <HeaderBar.BackButton />
+        <HeaderBar.LeftContent>
+          <DynamicBackButton />
+        </HeaderBar.LeftContent>
       </HeaderBar>
       <div className={pageStyles}>
         <div>

--- a/app/join/nickname/page.tsx
+++ b/app/join/nickname/page.tsx
@@ -2,22 +2,14 @@
 'use client';
 
 import { useAtomValue } from 'jotai';
-import dynamic from 'next/dynamic';
 import { useRouter } from 'next/navigation';
 import { useForm } from 'react-hook-form';
 
-import { Button, LeftArrowIcon } from '@/components/atoms';
-import { HeaderBar } from '@/components/molecules';
+import { Button } from '@/components/atoms';
+import { BackButton, HeaderBar } from '@/components/molecules';
 import { AuthInfoAtom } from '@/store/auth';
 import { css } from '@/styled-system/css';
 import { flex } from '@/styled-system/patterns';
-const DynamicBackButton = dynamic(
-  () => import('@/components/molecules').then(({ BackButton }) => BackButton),
-  {
-    ssr: false,
-    loading: () => <LeftArrowIcon />,
-  },
-);
 
 export interface NicknameData {
   nickname: string;
@@ -82,7 +74,7 @@ export default function JoinPage() {
   return (
     <div>
       <HeaderBar.LeftContent>
-        <DynamicBackButton />
+        <BackButton />
       </HeaderBar.LeftContent>
       <form onSubmit={handleSubmit(onSubmit)}>
         <div

--- a/app/join/nickname/page.tsx
+++ b/app/join/nickname/page.tsx
@@ -2,14 +2,22 @@
 'use client';
 
 import { useAtomValue } from 'jotai';
+import dynamic from 'next/dynamic';
 import { useRouter } from 'next/navigation';
 import { useForm } from 'react-hook-form';
 
-import { Button } from '@/components/atoms';
+import { Button, LeftArrowIcon } from '@/components/atoms';
 import { HeaderBar } from '@/components/molecules';
 import { AuthInfoAtom } from '@/store/auth';
 import { css } from '@/styled-system/css';
 import { flex } from '@/styled-system/patterns';
+const DynamicBackButton = dynamic(
+  () => import('@/components/molecules').then(({ BackButton }) => BackButton),
+  {
+    ssr: false,
+    loading: () => <LeftArrowIcon />,
+  },
+);
 
 export interface NicknameData {
   nickname: string;
@@ -73,9 +81,9 @@ export default function JoinPage() {
 
   return (
     <div>
-      <HeaderBar className={css({ marginBottom: '24px' })}>
-        <HeaderBar.BackButton />
-      </HeaderBar>
+      <HeaderBar.LeftContent>
+        <DynamicBackButton />
+      </HeaderBar.LeftContent>
       <form onSubmit={handleSubmit(onSubmit)}>
         <div
           className={flex({

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,8 +1,9 @@
 'use client';
 
+import dynamic from 'next/dynamic';
 import { useState } from 'react';
 
-import { BellIcon, SettingIcon } from '@/components/atoms';
+import { BellIcon, LogoIcon, SettingIcon } from '@/components/atoms';
 import { HeaderBar } from '@/components/molecules';
 import {
   MainTab,
@@ -12,6 +13,13 @@ import {
 } from '@/features/main';
 import { css } from '@/styled-system/css';
 import { flex } from '@/styled-system/patterns';
+const DynamicLogoButton = dynamic(
+  () => import('@/components/molecules').then(({ LogoButton }) => LogoButton),
+  {
+    ssr: false,
+    loading: () => <LogoIcon />,
+  },
+);
 
 const SELECT_CALENDAR_VIEW = 0;
 const SELECT_TIMELINE_VIEW = 1;
@@ -35,7 +43,9 @@ export default function Home() {
   return (
     <>
       <HeaderBar>
-        <HeaderBar.LogoButton className={css({ left: '20px' })} />
+        <HeaderBar.LeftContent className={css({ left: '20px' })}>
+          <DynamicLogoButton />
+        </HeaderBar.LeftContent>
         <HeaderBar.RightContent className={css({ right: '20px' })}>
           {[
             { component: <BellIcon />, key: 'bell' },

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,10 +1,9 @@
 'use client';
 
-import dynamic from 'next/dynamic';
 import { useState } from 'react';
 
-import { BellIcon, LogoIcon, SettingIcon } from '@/components/atoms';
-import { HeaderBar } from '@/components/molecules';
+import { BellIcon, SettingIcon } from '@/components/atoms';
+import { HeaderBar, LogoButton } from '@/components/molecules';
 import {
   MainTab,
   TabItemInfo,
@@ -13,13 +12,6 @@ import {
 } from '@/features/main';
 import { css } from '@/styled-system/css';
 import { flex } from '@/styled-system/patterns';
-const DynamicLogoButton = dynamic(
-  () => import('@/components/molecules').then(({ LogoButton }) => LogoButton),
-  {
-    ssr: false,
-    loading: () => <LogoIcon />,
-  },
-);
 
 const SELECT_CALENDAR_VIEW = 0;
 const SELECT_TIMELINE_VIEW = 1;
@@ -44,7 +36,7 @@ export default function Home() {
     <>
       <HeaderBar>
         <HeaderBar.LeftContent className={css({ left: '20px' })}>
-          <DynamicLogoButton />
+          <LogoButton />
         </HeaderBar.LeftContent>
         <HeaderBar.RightContent className={css({ right: '20px' })}>
           {[

--- a/app/profile/[id]/follow/page.tsx
+++ b/app/profile/[id]/follow/page.tsx
@@ -1,8 +1,16 @@
 import dynamic from 'next/dynamic';
 
+import { LeftArrowIcon } from '@/components/atoms';
 import { HeaderBar, ProfileListItem } from '@/components/molecules';
 import { type FollowTab } from '@/features/follow';
 import { flex } from '@/styled-system/patterns';
+const DynamicBackButton = dynamic(
+  () => import('@/components/molecules').then(({ BackButton }) => BackButton),
+  {
+    ssr: false,
+    loading: () => <LeftArrowIcon />,
+  },
+);
 
 const DynamicTabSection = dynamic(
   () =>
@@ -24,7 +32,9 @@ export default function ProfileFollow({
   return (
     <>
       <HeaderBar>
-        <HeaderBar.BackButton />
+        <HeaderBar.LeftContent>
+          <DynamicBackButton />
+        </HeaderBar.LeftContent>
         <HeaderBar.Title>수영왕 정지영</HeaderBar.Title>
       </HeaderBar>
       <DynamicTabSection tab={tab} />

--- a/app/profile/edit/page.tsx
+++ b/app/profile/edit/page.tsx
@@ -1,12 +1,24 @@
+import dynamic from 'next/dynamic';
+
+import { LeftArrowIcon } from '@/components/atoms';
 import { HeaderBar } from '@/components/molecules';
 import { BlueTextButton, ProfileEditForm } from '@/features/profile';
+const DynamicBackButton = dynamic(
+  () => import('@/components/molecules').then(({ BackButton }) => BackButton),
+  {
+    ssr: false,
+    loading: () => <LeftArrowIcon />,
+  },
+);
 
 //Todo: api 연결
 export default function ProfileEditPage() {
   return (
     <>
       <HeaderBar>
-        <HeaderBar.BackButton />
+        <HeaderBar.LeftContent>
+          <DynamicBackButton />
+        </HeaderBar.LeftContent>
         <HeaderBar.Title>프로필 편집</HeaderBar.Title>
         <HeaderBar.RightContent>
           {[{ component: <BlueTextButton label="저장" />, key: 'save' }]}

--- a/app/record-detail/[id]/page.tsx
+++ b/app/record-detail/[id]/page.tsx
@@ -1,7 +1,7 @@
 import dynamic from 'next/dynamic';
 
 import { fetchData } from '@/apis/fetch-data';
-import { LoadingArea } from '@/components/atoms';
+import { LeftArrowIcon, LoadingArea } from '@/components/atoms';
 import { HeaderBar } from '@/components/molecules';
 import {
   DetailDescriptionSection,
@@ -11,6 +11,13 @@ import {
 import { EditButton } from '@/features/record-detail/components';
 import { css } from '@/styled-system/css';
 import { flex } from '@/styled-system/patterns';
+const DynamicBackButton = dynamic(
+  () => import('@/components/molecules').then(({ BackButton }) => BackButton),
+  {
+    ssr: false,
+    loading: () => <LeftArrowIcon />,
+  },
+);
 
 const DynamicPreviewSection = dynamic(
   () =>
@@ -49,7 +56,9 @@ export default async function RecordDetail({ params }: RecordDetail) {
   return (
     <>
       <HeaderBar>
-        <HeaderBar.BackButton />
+        <HeaderBar.LeftContent>
+          <DynamicBackButton />
+        </HeaderBar.LeftContent>
         <HeaderBar.Title>
           {data.member?.name ?? '스위미'}의 수영 기록
         </HeaderBar.Title>

--- a/app/record/page.tsx
+++ b/app/record/page.tsx
@@ -1,15 +1,26 @@
+import dynamic from 'next/dynamic';
 import { Suspense } from 'react';
 
+import { LeftArrowIcon } from '@/components/atoms';
 import { HeaderBar } from '@/components/molecules';
 import { Form } from '@/features/record';
 import { css } from '@/styled-system/css';
 import { flex } from '@/styled-system/patterns';
+const DynamicBackButton = dynamic(
+  () => import('@/components/molecules').then(({ BackButton }) => BackButton),
+  {
+    ssr: false,
+    loading: () => <LeftArrowIcon />,
+  },
+);
 
 export default function RecordPage() {
   return (
     <div>
       <HeaderBar className={css({ marginBottom: '24px' })}>
-        <HeaderBar.BackButton />
+        <HeaderBar.LeftContent>
+          <DynamicBackButton />
+        </HeaderBar.LeftContent>
         <HeaderBar.Title>수영 기록하기</HeaderBar.Title>
       </HeaderBar>
       {/* Title 컴포넌트 생성 시 대체 */}

--- a/components/molecules/header-bar/header-bar.tsx
+++ b/components/molecules/header-bar/header-bar.tsx
@@ -1,4 +1,3 @@
-import dynamic from 'next/dynamic';
 import {
   Children,
   FunctionComponent,
@@ -7,59 +6,18 @@ import {
   ReactNode,
 } from 'react';
 
-import { LeftArrowIcon, LogoIcon } from '@/components/atoms';
 import { css, cx } from '@/styled-system/css';
 import { flex } from '@/styled-system/patterns';
 
-const DynamicBackButton = dynamic(
-  () => import('./header-back-button').then(({ BackButton }) => BackButton),
-  {
-    ssr: false,
-    loading: () => (
-      <div className={cx(leftIconStyles)}>
-        <LeftArrowIcon />
-      </div>
-    ),
-  },
-);
-const DynamicLogoButton = dynamic(
-  () => import('./header-logo-button').then(({ LogoButton }) => LogoButton),
-  {
-    ssr: false,
-    loading: () => (
-      <div className={cx(leftIconStyles)}>
-        <LogoIcon />
-      </div>
-    ),
-  },
-);
+import { leftIconStyles } from './style';
 
-interface BackButtonProps {
-  onClick?: () => void;
+interface LeftContentProps {
+  children?: ReactNode;
   className?: string;
 }
 
-function BackButton({ onClick, className }: BackButtonProps) {
-  return (
-    <DynamicBackButton
-      className={cx(leftIconStyles, className)}
-      onClickBack={onClick}
-    />
-  );
-}
-
-interface LogoButtonProps {
-  onClick?: () => void;
-  className?: string;
-}
-
-function LogoButton({ onClick, className }: LogoButtonProps) {
-  return (
-    <DynamicLogoButton
-      className={cx(leftIconStyles, className)}
-      onClickLogo={onClick}
-    />
-  );
+function LeftContent({ children, className }: LeftContentProps) {
+  return <div className={cx(leftIconStyles, className)}>{children}</div>;
 }
 
 interface TitleProps {
@@ -106,22 +64,17 @@ interface HeaderBarProps {
 }
 
 function HeaderBarLayout({ children, className }: HeaderBarProps) {
-  const backButton = getChildrenArray(
+  const leftContent = getChildrenArray(
     children,
     1,
-    (<BackButton />).type as FunctionComponent,
-  );
-  const logoButton = getChildrenArray(
-    children,
-    1,
-    (<LogoButton />).type as FunctionComponent,
+    (<LeftContent />).type as FunctionComponent,
   );
   const title = getChildrenArray(
     children,
     1,
     (<Title />).type as FunctionComponent,
   );
-  const rightIcons = getChildrenArray(
+  const rightContent = getChildrenArray(
     children,
     2,
     (<RightContent />).type as FunctionComponent,
@@ -131,10 +84,9 @@ function HeaderBarLayout({ children, className }: HeaderBarProps) {
       <div style={{ height: '44px' }} className={className} />
       <header className={layoutStyles.header}>
         <div className={layoutStyles.content}>
-          {backButton}
-          {logoButton}
+          {leftContent}
           {title}
-          {rightIcons}
+          {rightContent}
         </div>
       </header>
     </>
@@ -142,8 +94,7 @@ function HeaderBarLayout({ children, className }: HeaderBarProps) {
 }
 
 export const HeaderBar = Object.assign(HeaderBarLayout, {
-  BackButton,
-  LogoButton,
+  LeftContent,
   Title,
   RightContent,
 });
@@ -172,11 +123,6 @@ const layoutStyles = {
     gap: '24px',
   }),
 };
-
-const leftIconStyles = css({
-  position: 'absolute',
-  left: '12px',
-});
 
 const titleStyles = flex({
   justifyContent: 'center',

--- a/components/molecules/header-bar/header-logo-button.tsx
+++ b/components/molecules/header-bar/header-logo-button.tsx
@@ -1,24 +1,18 @@
 'use client';
 
-import { useRouter } from 'next/navigation';
+import Link from 'next/link';
 
 import { LogoIcon } from '@/components/atoms';
 
 interface LogoButtonProps {
-  onClickLogo?: () => void;
+  route?: string;
   className?: string;
 }
 
-export function LogoButton({ onClickLogo, className }: LogoButtonProps) {
-  const router = useRouter();
-
-  const handleLogoClick = () => {
-    onClickLogo ? onClickLogo : router.push('/');
-  };
-
+export function LogoButton({ route = '/', className }: LogoButtonProps) {
   return (
-    <button className={className} onClick={handleLogoClick}>
+    <Link href={route} className={className}>
       <LogoIcon />
-    </button>
+    </Link>
   );
 }

--- a/components/molecules/header-bar/index.ts
+++ b/components/molecules/header-bar/index.ts
@@ -1,3 +1,4 @@
 export * from './header-back-button';
 export * from './header-bar';
 export * from './header-logo-button';
+export * from './style';

--- a/components/molecules/header-bar/style.ts
+++ b/components/molecules/header-bar/style.ts
@@ -1,0 +1,7 @@
+import { flex } from '@/styled-system/patterns';
+
+export const leftIconStyles = flex({
+  position: 'absolute',
+  alignItems: 'center',
+  left: '12px',
+});

--- a/features/record/components/organisms/distance-page-modal.tsx
+++ b/features/record/components/organisms/distance-page-modal.tsx
@@ -1,9 +1,10 @@
 'use client';
 
 import { useAtomValue } from 'jotai';
+import dynamic from 'next/dynamic';
 import { useFormContext, useWatch } from 'react-hook-form';
 
-import { Button } from '@/components/atoms';
+import { Button, LeftArrowIcon } from '@/components/atoms';
 import {
   HeaderBar,
   PageModal,
@@ -18,6 +19,13 @@ import { useDistancePageModal } from '../../hooks';
 import { isDistancePageModalOpen } from '../../store';
 import { StrokeProps } from '../../types';
 import { StrokeDistanceFields } from './stroke-distance-fields';
+const DynamicBackButton = dynamic(
+  () => import('@/components/molecules').then(({ BackButton }) => BackButton),
+  {
+    ssr: false,
+    loading: () => <LeftArrowIcon />,
+  },
+);
 
 interface DistancePageModalProps {
   defaultStrokes?: StrokeProps[];
@@ -137,7 +145,9 @@ export function DistancePageModal({
     >
       <div ref={pageModalRef}>
         <HeaderBar>
-          <HeaderBar.BackButton onClick={handleBackArrowClick} />
+          <HeaderBar.LeftContent>
+            <DynamicBackButton onClickBack={handleBackArrowClick} />
+          </HeaderBar.LeftContent>
         </HeaderBar>
         <h1 className={titleStyles}>수영 거리를 입력해주세요</h1>
         <section className={layout.tab}>

--- a/features/record/components/organisms/distance-page-modal.tsx
+++ b/features/record/components/organisms/distance-page-modal.tsx
@@ -1,11 +1,11 @@
 'use client';
 
 import { useAtomValue } from 'jotai';
-import dynamic from 'next/dynamic';
 import { useFormContext, useWatch } from 'react-hook-form';
 
-import { Button, LeftArrowIcon } from '@/components/atoms';
+import { Button } from '@/components/atoms';
 import {
+  BackButton,
   HeaderBar,
   PageModal,
   Tab,
@@ -19,13 +19,6 @@ import { useDistancePageModal } from '../../hooks';
 import { isDistancePageModalOpen } from '../../store';
 import { StrokeProps } from '../../types';
 import { StrokeDistanceFields } from './stroke-distance-fields';
-const DynamicBackButton = dynamic(
-  () => import('@/components/molecules').then(({ BackButton }) => BackButton),
-  {
-    ssr: false,
-    loading: () => <LeftArrowIcon />,
-  },
-);
 
 interface DistancePageModalProps {
   defaultStrokes?: StrokeProps[];
@@ -146,7 +139,7 @@ export function DistancePageModal({
       <div ref={pageModalRef}>
         <HeaderBar>
           <HeaderBar.LeftContent>
-            <DynamicBackButton onClickBack={handleBackArrowClick} />
+            <BackButton onClickBack={handleBackArrowClick} />
           </HeaderBar.LeftContent>
         </HeaderBar>
         <h1 className={titleStyles}>수영 거리를 입력해주세요</h1>

--- a/features/record/components/organisms/pool-search-page-modal.tsx
+++ b/features/record/components/organisms/pool-search-page-modal.tsx
@@ -14,11 +14,22 @@ const PoolSearchResultElement = lazy(() =>
     default: module.PoolSearchResultElement,
   })),
 );
+import dynamic from 'next/dynamic';
+
+import { LeftArrowIcon } from '@/components/atoms';
+
 import { PoolSearchSkeleton } from '../skeleton/pool-search-skeleton';
 const PoolSearchResultList = lazy(() =>
   import('./pool-search-result-list').then((module) => ({
     default: module.PoolSearchResultList,
   })),
+);
+const DynamicBackButton = dynamic(
+  () => import('@/components/molecules').then(({ BackButton }) => BackButton),
+  {
+    ssr: false,
+    loading: () => <LeftArrowIcon />,
+  },
 );
 
 interface PoolSearchPageModalProps {
@@ -49,7 +60,11 @@ export function PoolSearchPageModal({ title }: PoolSearchPageModalProps) {
     >
       <div ref={pageModalRef}>
         <HeaderBar>
-          <HeaderBar.BackButton onClick={() => handlers.onClosePageModal()} />
+          <HeaderBar.LeftContent>
+            <DynamicBackButton
+              onClickBack={() => handlers.onClosePageModal()}
+            />
+          </HeaderBar.LeftContent>
         </HeaderBar>
         <div className={layoutStyles}>
           <h2 className={textStyles.title}>{title}</h2>

--- a/features/record/components/organisms/pool-search-page-modal.tsx
+++ b/features/record/components/organisms/pool-search-page-modal.tsx
@@ -3,7 +3,7 @@
 import { debounce } from 'lodash';
 import { lazy, Suspense, useState } from 'react';
 
-import { HeaderBar, PageModal } from '@/components/molecules';
+import { BackButton, HeaderBar, PageModal } from '@/components/molecules';
 import { SearchBar } from '@/components/molecules/search-bar';
 import { css } from '@/styled-system/css';
 
@@ -14,22 +14,12 @@ const PoolSearchResultElement = lazy(() =>
     default: module.PoolSearchResultElement,
   })),
 );
-import dynamic from 'next/dynamic';
-
-import { LeftArrowIcon } from '@/components/atoms';
 
 import { PoolSearchSkeleton } from '../skeleton/pool-search-skeleton';
 const PoolSearchResultList = lazy(() =>
   import('./pool-search-result-list').then((module) => ({
     default: module.PoolSearchResultList,
   })),
-);
-const DynamicBackButton = dynamic(
-  () => import('@/components/molecules').then(({ BackButton }) => BackButton),
-  {
-    ssr: false,
-    loading: () => <LeftArrowIcon />,
-  },
 );
 
 interface PoolSearchPageModalProps {
@@ -61,9 +51,7 @@ export function PoolSearchPageModal({ title }: PoolSearchPageModalProps) {
       <div ref={pageModalRef}>
         <HeaderBar>
           <HeaderBar.LeftContent>
-            <DynamicBackButton
-              onClickBack={() => handlers.onClosePageModal()}
-            />
+            <BackButton onClickBack={() => handlers.onClosePageModal()} />
           </HeaderBar.LeftContent>
         </HeaderBar>
         <div className={layoutStyles}>


### PR DESCRIPTION
## 🤔 어떤 문제가 발생했나요?

- header-bar 컴포넌트의 왼쪽 구역에 들어갈 아이콘 종류가 생각보다 많았습니다.

## 🎉 어떻게 해결했나요?

- 왼쪽 구역에 들어갈 아이콘을 정해두지 않고, ReactNode 타입의 children 속성으로 외부에서 넣을 수 있도록 하여 자유도를 높였습니다.

### 📷 이미지 첨부 (Option)

- 서버 컴포넌트 내부에서 사용 시 -> children에 들어갈 요소 dynamic import 후 사용

<img width="557" alt="image" src="https://github.com/user-attachments/assets/3b9b107c-f5b6-4858-ad83-d512d167f9dd">
<img width="230" alt="image" src="https://github.com/user-attachments/assets/88a7816e-9e3e-424f-881f-8773ab51d195">

- 클라이언트 컴포넌트 내부에서 사용 시 -> children에 들어갈 요소 일반 import 후 사용

<img width="192" alt="image" src="https://github.com/user-attachments/assets/679db51d-6507-44df-a17f-b6a21329d79e">

- 외부 스타일 주입 필요 시 className 속성으로 부여

<img width="429" alt="image" src="https://github.com/user-attachments/assets/30ae5b35-8c7d-4ce6-b822-db00b4f4816a">

### ⚠️ 유의할 점! (Option)

- HeaderBar 컴포넌트 사용중인 모든 페이지에 수정사항 적용하였습니다.
- 오른쪽 요소인 RightContent 에 들어갈 요소들도 서버 컴포넌트 내부에서는 dynamic import 처리 해주면 좋을 것 같아요~!!