### PR TITLE
feat: cheer progress 마크업 및 동작을 구현합니다

### DIFF
--- a/app/record-detail/[id]/page.tsx
+++ b/app/record-detail/[id]/page.tsx
@@ -27,9 +27,21 @@ const DynamicPreviewSection = dynamic(
   },
 );
 
-const DynamicCheerSection = dynamic(
+const DynamicCheerFabSection = dynamic(
   () =>
-    import('@/features/record-detail').then(({ DetailCheer }) => DetailCheer),
+    import('@/features/record-detail').then(
+      ({ DetailCheerFabSection }) => DetailCheerFabSection,
+    ),
+  {
+    ssr: false,
+  },
+);
+
+const DynamicCheerModalSection = dynamic(
+  () =>
+    import('@/features/record-detail').then(
+      ({ DetailCheerModalSection }) => DetailCheerModalSection,
+    ),
   {
     ssr: false,
   },
@@ -62,8 +74,12 @@ export default async function RecordDetail({ params }: RecordDetail) {
 
       <article className={containerStyle}>
         <div>
-          {/* cheer section */}
-          <DynamicCheerSection data={data} />
+          {/* cheer modal section */}
+          <DynamicCheerModalSection data={data} />
+
+          {/* cheer fab section */}
+          <DynamicCheerFabSection data={data} />
+
           {/* preview section */}
           <DynamicPreviewSection data={data} />
         </div>

--- a/features/record-detail/components/cheer-progress.tsx
+++ b/features/record-detail/components/cheer-progress.tsx
@@ -34,7 +34,7 @@ export const CheerProgress = ({
       const removeTimeout = setTimeout(() => {
         setIsVisible(false);
         onChangeOpen(false);
-      }, 1500); // wait for fade-out transition to complete
+      }, 1500);
 
       return () => {
         clearTimeout(hideTimeout);

--- a/features/record-detail/components/cheer-progress.tsx
+++ b/features/record-detail/components/cheer-progress.tsx
@@ -1,0 +1,121 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+
+import { css, cx } from '@/styled-system/css';
+import { flex } from '@/styled-system/patterns';
+
+import { DetailCheerItem } from '../types';
+
+type CheerProgress = {
+  isOpen: boolean;
+  onChangeOpen: (isOpen: boolean) => void;
+  authorName: string;
+  cheerItem?: DetailCheerItem;
+};
+export const CheerProgress = ({
+  isOpen,
+  onChangeOpen,
+  authorName,
+  cheerItem,
+}: CheerProgress) => {
+  const [isVisible, setIsVisible] = useState(false);
+  const [isFadingOut, setIsFadingOut] = useState(false);
+
+  useEffect(() => {
+    if (isOpen) {
+      setIsVisible(true);
+      setIsFadingOut(false);
+
+      const hideTimeout = setTimeout(() => {
+        setIsFadingOut(true);
+      }, 1200);
+
+      const removeTimeout = setTimeout(() => {
+        setIsVisible(false);
+        onChangeOpen(false);
+      }, 1500); // wait for fade-out transition to complete
+
+      return () => {
+        clearTimeout(hideTimeout);
+        clearTimeout(removeTimeout);
+      };
+    }
+  }, [isOpen, onChangeOpen]);
+
+  if (!isVisible || !cheerItem) return null;
+  return (
+    <div className={cx(containerStyle, isFadingOut && 'fade-out')}>
+      <div className={content.wrapperStyle}>
+        <h1 className={content.titleStyle}>
+          {authorName}님에게
+          <br />
+          응원을 보내고 있어요!
+        </h1>
+        <div className={content.badgeStyle}>
+          <p className={content.descriptionStyle}>
+            {cheerItem.emoji}{' '}
+            {cheerItem.comment && <span>{cheerItem.comment}</span>}
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+const containerStyle = css({
+  position: 'fixed',
+  top: '50%',
+  left: '50%',
+  translate: 'auto',
+  translateX: '-1/2',
+  translateY: '-1/2',
+  width: 'full',
+  maxWidth: 'maxWidth',
+  m: '0 auto',
+  height: 'full',
+  backgroundColor: '#171719',
+  zIndex: '200',
+
+  opacity: 1,
+  transition: 'opacity 300ms ease-out',
+  '&.fade-out': {
+    opacity: 0,
+  },
+});
+
+const content = {
+  wrapperStyle: flex({
+    direction: 'column',
+    gap: '20px',
+    position: 'fixed',
+    top: '50%',
+    left: '50%',
+    translate: 'auto',
+    translateX: '-1/2',
+    translateY: '-1/2',
+  }),
+
+  titleStyle: css({
+    textStyle: 'body1.normal',
+    fontWeight: 'bold',
+    color: 'white',
+    textAlign: 'center',
+  }),
+
+  badgeStyle: css({
+    p: '10px 18px',
+    backgroundColor: 'white',
+    rounded: '8px',
+  }),
+
+  descriptionStyle: css({
+    textStyle: 'heading4',
+    fontWeight: 'bold',
+    color: 'text.normal',
+
+    '& > span': {
+      ml: '8px',
+    },
+  }),
+};

--- a/features/record-detail/components/cheer-progress.tsx
+++ b/features/record-detail/components/cheer-progress.tsx
@@ -55,7 +55,9 @@ export const CheerProgress = ({
         <div className={content.badgeStyle}>
           <p className={content.descriptionStyle}>
             {cheerItem.emoji}{' '}
-            {cheerItem.comment && <span>{cheerItem.comment}</span>}
+            {Boolean(cheerItem.comment?.length) && (
+              <span>{cheerItem.comment}</span>
+            )}
           </p>
         </div>
       </div>
@@ -87,6 +89,7 @@ const containerStyle = css({
 const content = {
   wrapperStyle: flex({
     direction: 'column',
+    alignItems: 'center',
     gap: '20px',
     position: 'fixed',
     top: '50%',
@@ -104,6 +107,7 @@ const content = {
   }),
 
   badgeStyle: css({
+    width: 'fit-content',
     p: '10px 18px',
     backgroundColor: 'white',
     rounded: '8px',

--- a/features/record-detail/components/index.ts
+++ b/features/record-detail/components/index.ts
@@ -1,6 +1,7 @@
 export * from './cheer-bottom-sheet';
 export * from './cheer-item';
 export * from './cheer-modal';
+export * from './cheer-progress';
 export * from './date-picker';
 export * from './edit-button';
 export * from './swim-description-item';

--- a/features/record-detail/sections/detail-cheer-fab.tsx
+++ b/features/record-detail/sections/detail-cheer-fab.tsx
@@ -2,25 +2,17 @@
 
 import { useState } from 'react';
 
-import { useBottomSheet, useDragScroll, useModal } from '@/hooks';
+import { useBottomSheet } from '@/hooks';
 import { css } from '@/styled-system/css';
-import { flex } from '@/styled-system/patterns';
 
 import { useCheer, useCheerPreviewList } from '../apis';
-import {
-  CheerBottomSheet,
-  CheerItem,
-  CheerModal,
-  CheerProgress,
-} from '../components';
+import { CheerBottomSheet, CheerProgress } from '../components';
 import { initialCheerList } from '../data';
 import { DetailCheerItemSelected, RecordDetailType } from '../types';
 
-export const DetailCheer = ({ data }: { data: RecordDetailType }) => {
+export const DetailCheerFabSection = ({ data }: { data: RecordDetailType }) => {
   const { mutate: mutateCheer } = useCheer();
-  const { data: cheerPreviewData, refetch: refetchCheer } = useCheerPreviewList(
-    data.id,
-  );
+  const { refetch: refetchCheer } = useCheerPreviewList(data.id);
 
   const [cheerList, setCheerList] = useState(initialCheerList);
   const [selectedCheerItem, setSelectedCheerItem] =
@@ -31,13 +23,6 @@ export const DetailCheer = ({ data }: { data: RecordDetailType }) => {
     open: openBottomSheet,
     close: closeBottomSheet,
   } = useBottomSheet();
-  const {
-    isOpen: isOpenModal,
-    open: openModal,
-    close: closeModal,
-  } = useModal();
-
-  const { sliderRef } = useDragScroll();
 
   const handleClickCheerItem = (index: number) => {
     setCheerList((prev) =>
@@ -81,30 +66,9 @@ export const DetailCheer = ({ data }: { data: RecordDetailType }) => {
   };
 
   const { isMyMemory } = data;
-  const reactions = cheerPreviewData?.reactions || [];
+
   return (
     <>
-      {/* NOTE: 응원 미리보기 목록 */}
-      {reactions && Boolean(reactions.length) && (
-        <div className={slider.containerStyle} ref={sliderRef}>
-          <div className={slider.wrapperStyle}>
-            {reactions.map((item) => (
-              <CheerItem
-                {...item}
-                key={item.reactionId}
-                onClick={openModal}
-                size="small"
-              />
-            ))}
-            {reactions.length > 10 && (
-              <button className={slider.entireCheerButton} onClick={openModal}>
-                응원 전체보기
-              </button>
-            )}
-          </div>
-        </div>
-      )}
-
       {/* NOTE: 응원 FAB Button */}
       {!isMyMemory && (
         <button className={cheerButtonWrapperStyle} onClick={openBottomSheet}>
@@ -120,14 +84,6 @@ export const DetailCheer = ({ data }: { data: RecordDetailType }) => {
         cheerItem={selectedCheerItem}
       />
 
-      {/* NOTE: 응원 모달 */}
-      <CheerModal
-        isOpen={isOpenModal}
-        onClose={closeModal}
-        title="8월 16일의 응원"
-        description="5"
-      />
-
       {/* NOTE: 응원 바텀시트 */}
       <CheerBottomSheet
         header={{ title: '응원 보내기' }}
@@ -139,33 +95,6 @@ export const DetailCheer = ({ data }: { data: RecordDetailType }) => {
       />
     </>
   );
-};
-
-const slider = {
-  containerStyle: css({
-    overflowX: 'scroll',
-    backgroundColor: 'white',
-
-    '&::-webkit-scrollbar': {
-      display: 'none',
-    },
-  }),
-
-  wrapperStyle: flex({
-    gap: '10px',
-    width: 'max-content',
-    backgroundColor: 'white',
-    p: '20px 20px 0px',
-  }),
-
-  entireCheerButton: css({
-    textStyle: 'label1.normal',
-    fontWeight: 'medium',
-    color: 'background.white',
-    backgroundColor: 'text.neutral',
-    rounded: '7px',
-    p: '7px 12px',
-  }),
 };
 
 const cheerButtonWrapperStyle = css({

--- a/features/record-detail/sections/detail-cheer-modal.tsx
+++ b/features/record-detail/sections/detail-cheer-modal.tsx
@@ -1,0 +1,85 @@
+'use client';
+
+import { useDragScroll, useModal } from '@/hooks';
+import { css } from '@/styled-system/css';
+import { flex } from '@/styled-system/patterns';
+
+import { useCheerPreviewList } from '../apis';
+import { CheerItem, CheerModal } from '../components';
+import { RecordDetailType } from '../types';
+
+export const DetailCheerModalSection = ({
+  data,
+}: {
+  data: RecordDetailType;
+}) => {
+  const { data: cheerPreviewData } = useCheerPreviewList(data.id);
+  const {
+    isOpen: isOpenModal,
+    open: openModal,
+    close: closeModal,
+  } = useModal();
+
+  const { sliderRef } = useDragScroll();
+
+  const reactions = cheerPreviewData?.reactions || [];
+  return (
+    <>
+      {/* NOTE: 응원 미리보기 목록 */}
+      {reactions && Boolean(reactions.length) && (
+        <div className={slider.containerStyle} ref={sliderRef}>
+          <div className={slider.wrapperStyle}>
+            {reactions.map((item) => (
+              <CheerItem
+                {...item}
+                key={item.reactionId}
+                onClick={openModal}
+                size="small"
+              />
+            ))}
+            {reactions.length > 10 && (
+              <button className={slider.entireCheerButton} onClick={openModal}>
+                응원 전체보기
+              </button>
+            )}
+          </div>
+        </div>
+      )}
+
+      {/* NOTE: 응원 모달 */}
+      <CheerModal
+        isOpen={isOpenModal}
+        onClose={closeModal}
+        title="8월 16일의 응원"
+        description="5"
+      />
+    </>
+  );
+};
+
+const slider = {
+  containerStyle: css({
+    overflowX: 'scroll',
+    backgroundColor: 'white',
+
+    '&::-webkit-scrollbar': {
+      display: 'none',
+    },
+  }),
+
+  wrapperStyle: flex({
+    gap: '10px',
+    width: 'max-content',
+    backgroundColor: 'white',
+    p: '20px 20px 0px',
+  }),
+
+  entireCheerButton: css({
+    textStyle: 'label1.normal',
+    fontWeight: 'medium',
+    color: 'background.white',
+    backgroundColor: 'text.neutral',
+    rounded: '7px',
+    p: '7px 12px',
+  }),
+};

--- a/features/record-detail/sections/detail-cheer.tsx
+++ b/features/record-detail/sections/detail-cheer.tsx
@@ -112,6 +112,7 @@ export const DetailCheer = ({ data }: { data: RecordDetailType }) => {
         </button>
       )}
 
+      {/* NOTE: 응원 Progress 모달 */}
       <CheerProgress
         isOpen={Boolean(selectedCheerItem)}
         onChangeOpen={handleChangeSelectedItem}

--- a/features/record-detail/sections/index.ts
+++ b/features/record-detail/sections/index.ts
@@ -1,4 +1,5 @@
-export * from './detail-cheer';
+export * from './detail-cheer-fab';
+export * from './detail-cheer-modal';
 export * from './detail-description';
 export * from './detail-diary';
 export * from './detail-preview';


### PR DESCRIPTION
<!-- 작성 예시 -->
<!-- # 어떤 문제가 발생했나요? -->
<!-- - 간략한 문제 설명 -->
<!-- - 문제 관련 링크 등등 -->
<!-- Ex) React v18 version update에 후 테스트에서 에러가 발생합니다.
  라이브러리의 버전이 호환이 되지않아서 문제입니다. -->

<!-- # 어떻게 해결했나요? -->
<!-- - 동작 방식 등 수정힌 코드에 대한 설명 -->
<!-- Ex) 라이브러리의 버전을 업데이트하고, v18을 사용할 수 있도록 dev dependency로 설치해주었습니다. -->

<!-- # 이미지 첨부 (Option) -->
<!-- - 이번 PR의 동작 이해를 돕는 GIF나 이미지 파일 첨부! -->
<!-- - 만약 없다면, NA 혹은 비워둡시다~ -->

<!-- # 유의할 점 (Option) -->
<!-- - 추가적으로 고민중이거나 조언을 구하고 싶은 내용, 어떤 것을 중점으로 리뷰를 해줬으면 좋겠는지 등등 작성 -->
<!-- - 만약 없다면, NA 혹은 비워둡시다~ -->

## 🤔 어떤 문제가 발생했나요?

-

## 🎉 어떻게 해결했나요?

- cheer progress component의 마크업 및 동작을 구현합니다.
1. 응원하기 버튼을 누르면 노출됩니다
2. 1200ms 기간동안 노출됩니다
3. 300ms 기간동안 fade-out 효과와 함께 사라집니다

TODO
- api 예외처리 구현
- 바텀 시트 / 응원 모달 flow 다른 컴포넌트로 분리

### 📷 이미지 첨부 (Option)

- MO

https://github.com/user-attachments/assets/674446cf-e386-4ccb-940e-e6240e683ddb

- PC


https://github.com/user-attachments/assets/9e24a6bf-f225-4f8f-929b-94ac1d6fa6b5


### ⚠️ 유의할 점! (Option)

-

<!-- PR merge시 닫을 이슈가 있다면, 번호를 작성해주세요 -->
<!-- Ex) close #12 -->
