### PR TITLE
fix: 타임라인 QA 이슈 해결 및 누락된 기능 추가

### DIFF
--- a/components/atoms/icons/divider-icon.tsx
+++ b/components/atoms/icons/divider-icon.tsx
@@ -1,0 +1,16 @@
+export const DividerIcon = () => {
+  return (
+    <svg
+      width="2"
+      height="14"
+      viewBox="0 0 2 14"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M1.91211 0.707031V13.3945H0.599609V0.707031H1.91211Z"
+        fill="#E1E2E4"
+      />
+    </svg>
+  );
+};

--- a/components/atoms/icons/index.ts
+++ b/components/atoms/icons/index.ts
@@ -8,6 +8,7 @@ export * from './date-arrow-icon';
 export * from './default-image-icon';
 export * from './default-profile-icon';
 export * from './delete-icon';
+export * from './divider-icon';
 export { DownArrowIcon } from './down-arrow-icon';
 export { LeftArrowIcon } from './left-arrow-icon';
 export * from './loading-icon';

--- a/features/main/components/time-line/molecules/time-line-card.tsx
+++ b/features/main/components/time-line/molecules/time-line-card.tsx
@@ -1,7 +1,7 @@
 import Link from 'next/link';
 import { PropsWithChildren, useEffect, useRef, useState } from 'react';
 
-import { Image, SwimmerIcon } from '@/components/atoms';
+import { DividerIcon, Image, SwimmerIcon } from '@/components/atoms';
 import { TimeLineContent } from '@/features/main/types';
 import { css } from '@/styled-system/css';
 import { flex } from '@/styled-system/patterns';
@@ -83,7 +83,12 @@ const TimeLineCardBody = ({
           )}
           <div className={descriptionStyles}>
             {startTime && endTime && <p>{`${startTime} ~ ${endTime}`}</p>}
-            {kcal && <p>{kcal}kcal</p>}
+            {kcal && (
+              <>
+                <DividerIcon />
+                <p>{kcal}kcal</p>
+              </>
+            )}
           </div>
         </div>
         {imageUrl && (
@@ -141,6 +146,7 @@ const completeStyles = flex({
 
 const descriptionStyles = flex({
   gap: '14px',
+  alignItems: 'center',
   textStyle: 'label1.normal',
   fontWeight: 'medium',
   color: 'neutral.70',

--- a/features/main/components/time-line/molecules/time-line-card.tsx
+++ b/features/main/components/time-line/molecules/time-line-card.tsx
@@ -1,7 +1,7 @@
 import Link from 'next/link';
 import { PropsWithChildren, useEffect, useRef, useState } from 'react';
 
-import { SwimmerIcon } from '@/components/atoms';
+import { Image, SwimmerIcon } from '@/components/atoms';
 import { TimeLineContent } from '@/features/main/types';
 import { css } from '@/styled-system/css';
 import { flex } from '@/styled-system/patterns';
@@ -60,6 +60,7 @@ const TimeLineCardBody = ({
   kcal,
   strokes,
   isAchieved,
+  imageUrl,
 }: TimeLineContent) => {
   const ref = useRef<HTMLDivElement | null>(null);
   const [currentWidth, setCurrentWidth] = useState<number>(0);
@@ -70,7 +71,7 @@ const TimeLineCardBody = ({
 
   return (
     <Link href={`/record-detail/${memoryId}`} className={cardWrapperStyles}>
-      <div className={flex()} ref={ref}>
+      <div className={cardInfoStyles} ref={ref}>
         <div className={titleStyles}>
           {type !== 'NORMAL' && totalDistance ? (
             <p>{formatMeters(totalDistance)}m</p>
@@ -85,6 +86,11 @@ const TimeLineCardBody = ({
             {kcal && <p>{kcal}kcal</p>}
           </div>
         </div>
+        {imageUrl && (
+          <div className={imageWrapperStyles}>
+            <Image src={imageUrl} alt="recorded image" fill />
+          </div>
+        )}
       </div>
       {strokes && totalDistance && isAchieved !== undefined && (
         <SwimRecordChart
@@ -116,6 +122,11 @@ const cardWrapperStyles = flex({
   borderRadius: '6px',
 });
 
+const cardInfoStyles = flex({
+  height: '100%',
+  justifyContent: 'space-between',
+});
+
 const titleStyles = flex({
   direction: 'column',
   '& > p': { textStyle: 'heading1', fontWeight: 'bold' },
@@ -135,6 +146,16 @@ const descriptionStyles = flex({
   color: 'neutral.70',
 });
 
+const imageWrapperStyles = flex({
+  position: 'relative',
+  width: '48px',
+  height: '60px',
+  alignItems: 'center',
+  justifyContent: 'center',
+  rounded: '2px',
+  overflow: 'hidden',
+});
+
 const diaryStyles = css({
   maxHeight: '2.5rem',
   textOverflow: 'ellipsis',
@@ -146,11 +167,3 @@ const diaryStyles = css({
   fontWeight: 'medium',
   color: 'neutral.70',
 });
-
-/*
-text-overflow: ellipsis;
-  overflow: hidden;
-  word-break: break-word;
-  display: -webkit-box;
-  -webkit-line-clamp: 2;
-*/

--- a/features/main/components/time-line/organisms/time-line.tsx
+++ b/features/main/components/time-line/organisms/time-line.tsx
@@ -2,7 +2,7 @@
 import { css, cx } from '@/styled-system/css';
 import { flex } from '@/styled-system/patterns';
 import { TimeLineCard } from '../molecules';
-import { formatDateToKorean } from '@/utils';
+import { formatDateToKorean, getFormatDate } from '@/utils';
 import { Fragment } from 'react';
 import { CardWrapper } from '../atoms';
 import { InfiniteScroller } from '@/components/molecules';
@@ -69,7 +69,8 @@ export const TimeLine = () => {
 const groupBySameYearAndMonth = (contents: Array<TimeLineContent>) => {
   const grouped: { [key: string]: Array<TimeLineContent> } = contents.reduce(
     (acc: { [key: string]: Array<TimeLineContent> }, item: TimeLineContent) => {
-      const key = item.recordAt;
+      const { year, month } = getFormatDate({ dateStr: item.recordAt });
+      const key = `${year}-${month}`;
 
       if (!acc[key]) acc[key] = [];
       acc[key].push(item);

--- a/features/main/components/time-line/organisms/time-line.tsx
+++ b/features/main/components/time-line/organisms/time-line.tsx
@@ -23,7 +23,10 @@ export const TimeLine = () => {
   const groupedContents = groupBySameYearAndMonth(contents);
   const isEmptyTimeLine = contents.length === 0;
   const lastGroupIndex = groupedContents.length - 1;
-  const lastContentIndex = groupedContents[lastGroupIndex].contents.length - 1;
+  const lastContentIndex =
+    groupedContents[lastGroupIndex] === undefined
+      ? 0
+      : groupedContents[lastGroupIndex].contents.length - 1;
 
   return (
     <>
@@ -84,7 +87,7 @@ const groupBySameYearAndMonth = (contents: Array<TimeLineContent>) => {
   return result;
 };
 
-const fullspaceStyles = css({ width: 'full', height: 'full' });
+const fullspaceStyles = css({ pt: '55%', width: 'full', height: 'full' });
 
 const iconContainer = flex({
   direction: 'column',


### PR DESCRIPTION
<!-- 작성 예시 -->
<!-- # 어떤 문제가 발생했나요? -->
<!-- - 간략한 문제 설명 -->
<!-- - 문제 관련 링크 등등 -->
<!-- Ex) React v18 version update에 후 테스트에서 에러가 발생합니다.
  라이브러리의 버전이 호환이 되지않아서 문제입니다. -->

<!-- # 어떻게 해결했나요? -->
<!-- - 동작 방식 등 수정힌 코드에 대한 설명 -->
<!-- Ex) 라이브러리의 버전을 업데이트하고, v18을 사용할 수 있도록 dev dependency로 설치해주었습니다. -->

<!-- # 이미지 첨부 (Option) -->
<!-- - 이번 PR의 동작 이해를 돕는 GIF나 이미지 파일 첨부! -->
<!-- - 만약 없다면, NA 혹은 비워둡시다~ -->

<!-- # 유의할 점 (Option) -->
<!-- - 추가적으로 고민중이거나 조언을 구하고 싶은 내용, 어떤 것을 중점으로 리뷰를 해줬으면 좋겠는지 등등 작성 -->
<!-- - 만약 없다면, NA 혹은 비워둡시다~ -->

## 🤔 어떤 문제가 발생했나요?

- 타임라인 사진 표기 및 칼로리 옆 구분자 누락되었습니다.
- 타임라인 월 구분이 제대로 되지 않는 현상 발생하였습니다.
- 빈 타임라인의 경우, 아이콘이 중앙에 오지 않는 현상이 발생하였습니다.

## 🎉 어떻게 해결했나요?

- 구분자 아이콘 컴포는트를 추가하였습니다
- 월 구분을 위해 사용하는 key를 YYYY-MM 형태로 변환하여 사용하도록 하였습니다.

### 📷 이미지 첨부 (Option)

- 타임라인에서 사잔이 있는 경우 표기
![스크린샷 2024-08-22 오전 2 08 13](https://github.com/user-attachments/assets/92f6d162-5ffa-4273-962f-0fab823ce25d)

- 칼로리 구분자 추가
![스크린샷 2024-08-22 오전 2 03 19](https://github.com/user-attachments/assets/c7a18878-050d-44a3-a466-fed1d25db900)


- 타임라인 월 구분 정상화 및 무한스크롤 정상 동작

https://github.com/user-attachments/assets/431e34c5-8ae9-4e8e-88ad-051393ca61b0


### ⚠️ 유의할 점! (Option)

-

<!-- PR merge시 닫을 이슈가 있다면, 번호를 작성해주세요 -->
<!-- Ex) close #12 -->
