### PR TITLE
feat: 홈페이지에서 알림 버튼 클릭 시 알림 페이지로 이동되도록 구현

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import dynamic from 'next/dynamic';
 import { useState } from 'react';
 
 import { BellIcon, SettingIcon } from '@/components/atoms';
@@ -12,6 +13,13 @@ import {
 } from '@/features/main';
 import { css } from '@/styled-system/css';
 import { flex } from '@/styled-system/patterns';
+const DynamicAlarmButton = dynamic(
+  () => import('@/components/molecules').then(({ AlarmButton }) => AlarmButton),
+  {
+    ssr: false,
+    loading: () => <BellIcon />,
+  },
+);
 
 const SELECT_CALENDAR_VIEW = 0;
 const SELECT_TIMELINE_VIEW = 1;
@@ -40,7 +48,7 @@ export default function Home() {
         </HeaderBar.LeftContent>
         <HeaderBar.RightContent className={css({ right: '20px' })}>
           {[
-            { component: <BellIcon />, key: 'bell' },
+            { component: <DynamicAlarmButton />, key: 'bell' },
             { component: <SettingIcon />, key: 'setting' },
           ]}
         </HeaderBar.RightContent>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,10 +1,9 @@
 'use client';
 
-import dynamic from 'next/dynamic';
 import { useState } from 'react';
 
-import { BellIcon, SettingIcon } from '@/components/atoms';
-import { HeaderBar, LogoButton } from '@/components/molecules';
+import { SettingIcon } from '@/components/atoms';
+import { AlarmButton, HeaderBar, LogoButton } from '@/components/molecules';
 import {
   MainTab,
   TabItemInfo,
@@ -13,13 +12,6 @@ import {
 } from '@/features/main';
 import { css } from '@/styled-system/css';
 import { flex } from '@/styled-system/patterns';
-const DynamicAlarmButton = dynamic(
-  () => import('@/components/molecules').then(({ AlarmButton }) => AlarmButton),
-  {
-    ssr: false,
-    loading: () => <BellIcon />,
-  },
-);
 
 const SELECT_CALENDAR_VIEW = 0;
 const SELECT_TIMELINE_VIEW = 1;
@@ -48,7 +40,7 @@ export default function Home() {
         </HeaderBar.LeftContent>
         <HeaderBar.RightContent className={css({ right: '20px' })}>
           {[
-            { component: <DynamicAlarmButton />, key: 'bell' },
+            { component: <AlarmButton />, key: 'bell' },
             { component: <SettingIcon />, key: 'setting' },
           ]}
         </HeaderBar.RightContent>

--- a/components/molecules/header-bar/header-bar-alarm-button.tsx
+++ b/components/molecules/header-bar/header-bar-alarm-button.tsx
@@ -1,0 +1,17 @@
+'use client';
+
+import Link from 'next/link';
+
+import { BellIcon } from '@/components/atoms';
+
+interface LogoButtonProps {
+  className?: string;
+}
+
+export function AlarmButton({ className }: LogoButtonProps) {
+  return (
+    <Link href="/alarm" className={className}>
+      <BellIcon />
+    </Link>
+  );
+}

--- a/components/molecules/header-bar/index.ts
+++ b/components/molecules/header-bar/index.ts
@@ -1,4 +1,5 @@
 export * from './header-back-button';
 export * from './header-bar';
+export * from './header-bar-alarm-button';
 export * from './header-logo-button';
 export * from './style';


### PR DESCRIPTION
## 🤔 어떤 문제가 발생했나요?


## 🎉 어떻게 해결했나요?

- 홈페이지 헤더의 알림 버튼을 누르면 alarm 페이지로 routing 되도록 구현하였습니다.

### 📷 이미지 첨부 (Option)

https://github.com/user-attachments/assets/33554970-b480-47fa-83a4-7b62076c7a84

### ⚠️ 유의할 점! (Option)

- NA
