### PR TITLE
fix: calendar item에 적용되고 있던 height full 옵션을 제거합니다

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -42,6 +42,26 @@ export default function RootLayout({
 
 const containerStyle = css({
   minHeight: '100%',
-  borderLeft: '1px solid #eeeeee',
-  borderRight: '1px solid #eeeeee',
+
+  // NOTE: border option
+  '&:before, &:after': {
+    content: "''",
+    display: 'block',
+    width: '1px',
+    height: '100%',
+    position: 'fixed',
+    top: 0,
+    zIndex: 9999,
+    backgroundColor: '#8a8a8a1a',
+  },
+
+  '&:before': {
+    right: '50%',
+    transform: 'translate(-300px)',
+  },
+
+  '&:after': {
+    right: '50%',
+    transform: 'translate(300px)',
+  },
 });

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -17,11 +17,9 @@ export const metadata: Metadata = {
 const rootStyle = css({
   maxWidth: 'maxWidth',
   width: '100%',
-  height: 'auto',
-  minHeight: '100vh',
+  height: '100dvh',
   margin: '0 auto',
-  borderLeft: '1px solid #eeeeee',
-  borderRight: '1px solid #eeeeee',
+  overflow: 'scroll',
 });
 
 export default function RootLayout({
@@ -34,10 +32,16 @@ export default function RootLayout({
       <body className={rootStyle}>
         <ReactQueryProvider>
           <ReactQueryDevtools initialIsOpen={true} />
-          {children}
+          <div className={containerStyle}>{children}</div>
           <PortalRoot />
         </ReactQueryProvider>
       </body>
     </html>
   );
 }
+
+const containerStyle = css({
+  minHeight: '100%',
+  borderLeft: '1px solid #eeeeee',
+  borderRight: '1px solid #eeeeee',
+});

--- a/features/main/components/calendar/atoms/calendar-item.tsx
+++ b/features/main/components/calendar/atoms/calendar-item.tsx
@@ -76,7 +76,7 @@ const ItemLayout = ({
 
 const itemContainerStyles = flex({
   width: 'full',
-  height: 'full',
+  height: 'fit-content',
   flexDir: 'column',
   alignItems: 'center',
 

--- a/features/main/components/calendar/molecules/calendar.tsx
+++ b/features/main/components/calendar/molecules/calendar.tsx
@@ -68,7 +68,7 @@ export const Calendar = () => {
 
 const calendarContainerStyles = flex({
   width: 'full',
-  height: 'full',
+  height: '100%',
   flexDir: 'column',
   gap: '16px',
 });


### PR DESCRIPTION
<!-- 작성 예시 -->
<!-- # 어떤 문제가 발생했나요? -->
<!-- - 간략한 문제 설명 -->
<!-- - 문제 관련 링크 등등 -->
<!-- Ex) React v18 version update에 후 테스트에서 에러가 발생합니다.
  라이브러리의 버전이 호환이 되지않아서 문제입니다. -->

<!-- # 어떻게 해결했나요? -->
<!-- - 동작 방식 등 수정힌 코드에 대한 설명 -->
<!-- Ex) 라이브러리의 버전을 업데이트하고, v18을 사용할 수 있도록 dev dependency로 설치해주었습니다. -->

<!-- # 이미지 첨부 (Option) -->
<!-- - 이번 PR의 동작 이해를 돕는 GIF나 이미지 파일 첨부! -->
<!-- - 만약 없다면, NA 혹은 비워둡시다~ -->

<!-- # 유의할 점 (Option) -->
<!-- - 추가적으로 고민중이거나 조언을 구하고 싶은 내용, 어떤 것을 중점으로 리뷰를 해줬으면 좋겠는지 등등 작성 -->
<!-- - 만약 없다면, NA 혹은 비워둡시다~ -->

## 🤔 어떤 문제가 발생했나요?

-

## 🎉 어떻게 해결했나요?

- 캘린더 아이템 각각에 적용되고 있던 height full 옵션을 제거합니다
- layout css의 height 100vh 가 사파리에서 동작하지 않아 높이 값을 변경합니다

### 📷 이미지 첨부 (Option)

-

### ⚠️ 유의할 점! (Option)

-

<!-- PR merge시 닫을 이슈가 있다면, 번호를 작성해주세요 -->
<!-- Ex) close #12 -->
