### PR TITLE
fix: 마이페이지 padding 버그 수정 및 GNB를 추가합니다.

### DIFF
--- a/app/profile/[id]/page.tsx
+++ b/app/profile/[id]/page.tsx
@@ -9,8 +9,6 @@ import { OtherPage } from '@/features/profile/components/organisms/other-page';
 import { css } from '@/styled-system/css';
 import { flex } from '@/styled-system/patterns';
 
-export type ProfileType = 'statistics' | 'badge' | 'record';
-
 export type Mypage = {
   params: { id: number };
 };

--- a/app/profile/[id]/page.tsx
+++ b/app/profile/[id]/page.tsx
@@ -3,7 +3,7 @@
 import { useQuery } from '@tanstack/react-query';
 
 import { LoadingArea, SettingIcon } from '@/components/atoms';
-import { HeaderBar } from '@/components/molecules';
+import { GlobalNavigationBar, HeaderBar } from '@/components/molecules';
 import { MyProfile } from '@/features/profile/components/organisms/my-page';
 import { OtherPage } from '@/features/profile/components/organisms/other-page';
 import { css } from '@/styled-system/css';
@@ -68,6 +68,7 @@ export default function Profile({ params }: Mypage) {
       ) : (
         <OtherPage profileData={profileData} />
       )}
+      <GlobalNavigationBar />
     </article>
   );
 }

--- a/app/profile/[id]/page.tsx
+++ b/app/profile/[id]/page.tsx
@@ -4,6 +4,7 @@ import { useQuery } from '@tanstack/react-query';
 
 import { LoadingArea, SettingIcon } from '@/components/atoms';
 import { GlobalNavigationBar, HeaderBar } from '@/components/molecules';
+import { ProfileProps } from '@/features/profile';
 import { MyProfile } from '@/features/profile/components/organisms/my-page';
 import { OtherPage } from '@/features/profile/components/organisms/other-page';
 import { css } from '@/styled-system/css';
@@ -12,19 +13,6 @@ import { flex } from '@/styled-system/patterns';
 export type Mypage = {
   params: { id: number };
 };
-
-export interface ProfileProps {
-  status: number;
-  code: string;
-  data: {
-    memberId: number;
-    nickname: string;
-    isMyProfile: boolean;
-    followerCount: number;
-    followingCount: number;
-    introduction: string;
-  };
-}
 
 const fetchProfileData = async (id: number) => {
   const response = await fetch(`/api/profile/${id}`);

--- a/features/profile/components/organisms/index.ts
+++ b/features/profile/components/organisms/index.ts
@@ -1,3 +1,4 @@
 export * from './my-page';
 export * from './other-page';
+export * from './profile-container';
 export * from './profile-edit-form';

--- a/features/profile/components/organisms/my-page.tsx
+++ b/features/profile/components/organisms/my-page.tsx
@@ -6,11 +6,12 @@ import { ProfileProps } from '@/app/profile/[id]/page';
 import { Button } from '@/components/atoms';
 import BadgeIcon from '@/components/atoms/icons/badge-icon';
 import StatisticsIcon from '@/components/atoms/icons/statistics-icon';
-import { UserImageIcon } from '@/components/atoms/icons/user-image-icon';
 import { Tab, TabItem } from '@/components/molecules';
 import { css } from '@/styled-system/css';
 import { flex } from '@/styled-system/patterns';
 import { ProfileType } from '@/types/profileType';
+
+import ProfileContainer from './profile-container';
 
 export function MyProfile({
   profileData,
@@ -22,27 +23,7 @@ export function MyProfile({
   return (
     <div>
       <section className={profileContainer}>
-        <div className={inforWrapper}>
-          <UserImageIcon />
-          <div>
-            <div className={nameStyles}>{profileData.nickname}</div>
-            <div className={introStyles}>{profileData.introduction}</div>
-          </div>
-        </div>
-        <div className={friendStyles.container}>
-          <div className={friendStyles.item}>
-            <div className={friendStyles.type}>팔로워</div>
-            <div className={friendStyles.count}>
-              {profileData.followerCount}
-            </div>
-          </div>
-          <div className={friendStyles.item}>
-            <div className={friendStyles.type}>팔로잉</div>
-            <div className={friendStyles.count}>
-              {profileData.followingCount}
-            </div>
-          </div>
-        </div>
+        <ProfileContainer profileData={profileData} />
         <div className={buttonContainer}>
           <Button
             size="small"
@@ -104,48 +85,6 @@ const profileContainer = flex({
   gap: '20px',
   padding: '20px',
 });
-
-const inforWrapper = flex({
-  alignItems: 'flex-start',
-  gap: '21px',
-  alignSelf: 'stretch',
-});
-
-const nameStyles = css({
-  textStyle: 'heading3',
-  fontWeight: '600',
-  color: 'text.normal',
-});
-
-const introStyles = css({
-  textStyle: 'body2.normal',
-  fontWeight: '500',
-  color: 'text.alternative',
-  width: '254px',
-});
-
-const friendStyles = {
-  container: flex({
-    alignItems: 'center',
-    gap: '40px',
-    alignSelf: 'stretch',
-  }),
-  item: flex({
-    direction: 'column',
-    alignItems: 'flex-start',
-    gap: '2px',
-  }),
-  type: css({
-    textStyle: 'label2',
-    fontWeight: '500',
-    color: 'text.alternative',
-  }),
-  count: css({
-    textStyle: 'body2.normal',
-    fontWeight: '600',
-    color: 'text.normal',
-  }),
-};
 
 const buttonContainer = flex({
   width: '100%',

--- a/features/profile/components/organisms/my-page.tsx
+++ b/features/profile/components/organisms/my-page.tsx
@@ -20,40 +20,46 @@ export function MyProfile({
   const [selectedTab, setSelectedTab] = useState<ProfileType>('statistics');
 
   return (
-    <section className={profileContainer}>
-      <div className={inforWrapper}>
-        <UserImageIcon />
-        <div>
-          <div className={nameStyles}>{profileData.nickname}</div>
-          <div className={introStyles}>{profileData.introduction}</div>
+    <div>
+      <section className={profileContainer}>
+        <div className={inforWrapper}>
+          <UserImageIcon />
+          <div>
+            <div className={nameStyles}>{profileData.nickname}</div>
+            <div className={introStyles}>{profileData.introduction}</div>
+          </div>
         </div>
-      </div>
-      <div className={friendStyles.container}>
-        <div className={friendStyles.item}>
-          <div className={friendStyles.type}>팔로워</div>
-          <div className={friendStyles.count}>{profileData.followerCount}</div>
+        <div className={friendStyles.container}>
+          <div className={friendStyles.item}>
+            <div className={friendStyles.type}>팔로워</div>
+            <div className={friendStyles.count}>
+              {profileData.followerCount}
+            </div>
+          </div>
+          <div className={friendStyles.item}>
+            <div className={friendStyles.type}>팔로잉</div>
+            <div className={friendStyles.count}>
+              {profileData.followingCount}
+            </div>
+          </div>
         </div>
-        <div className={friendStyles.item}>
-          <div className={friendStyles.type}>팔로잉</div>
-          <div className={friendStyles.count}>{profileData.followingCount}</div>
+        <div className={buttonContainer}>
+          <Button
+            size="small"
+            label="프로필 편집"
+            buttonType="assistive"
+            variant="outlined"
+            className={buttonStyle}
+          />
+          <Button
+            size="small"
+            label="프로필 공유"
+            buttonType="assistive"
+            variant="outlined"
+            className={buttonStyle}
+          />
         </div>
-      </div>
-      <div className={buttonContainer}>
-        <Button
-          size="small"
-          label="프로필 편집"
-          buttonType="assistive"
-          variant="outlined"
-          className={buttonStyle}
-        />
-        <Button
-          size="small"
-          label="프로필 공유"
-          buttonType="assistive"
-          variant="outlined"
-          className={buttonStyle}
-        />
-      </div>
+      </section>
       <Tab type="primary">
         <TabItem
           text="통계"
@@ -88,7 +94,7 @@ export function MyProfile({
           </div>
         </div>
       )}
-    </section>
+    </div>
   );
 }
 

--- a/features/profile/components/organisms/my-page.tsx
+++ b/features/profile/components/organisms/my-page.tsx
@@ -2,7 +2,6 @@
 
 import { useState } from 'react';
 
-import { ProfileProps } from '@/app/profile/[id]/page';
 import { Button } from '@/components/atoms';
 import BadgeIcon from '@/components/atoms/icons/badge-icon';
 import StatisticsIcon from '@/components/atoms/icons/statistics-icon';
@@ -11,6 +10,7 @@ import { css } from '@/styled-system/css';
 import { flex } from '@/styled-system/patterns';
 import { ProfileType } from '@/types/profileType';
 
+import { ProfileProps } from '../../types/profile';
 import ProfileContainer from './profile-container';
 
 export function MyProfile({

--- a/features/profile/components/organisms/other-page.tsx
+++ b/features/profile/components/organisms/other-page.tsx
@@ -5,7 +5,6 @@ import { useState } from 'react';
 import { ProfileProps } from '@/app/profile/[id]/page';
 import BadgeIcon from '@/components/atoms/icons/badge-icon';
 import StatisticsIcon from '@/components/atoms/icons/statistics-icon';
-import { UserImageIcon } from '@/components/atoms/icons/user-image-icon';
 import { Tab, TabItem } from '@/components/molecules';
 import { Calendar } from '@/features/main';
 import { css } from '@/styled-system/css';
@@ -13,38 +12,19 @@ import { flex } from '@/styled-system/patterns';
 import { ProfileType } from '@/types/profileType';
 
 import FollowButton from '../atoms/follow-button';
+import ProfileContainer from './profile-container';
 
 export function OtherPage({
   profileData,
 }: {
   profileData: ProfileProps['data'];
 }) {
-  const [selectedTab, setSelectedTab] = useState<ProfileType>('statistics');
+  const [selectedTab, setSelectedTab] = useState<ProfileType>('record');
 
   return (
     <div>
       <section className={profileContainer}>
-        <div className={inforWrapper}>
-          <UserImageIcon />
-          <div>
-            <div className={nameStyles}>{profileData.nickname}</div>
-            <div className={introStyles}>{profileData.introduction}</div>
-          </div>
-        </div>
-        <div className={friendStyles.container}>
-          <div className={friendStyles.item}>
-            <div className={friendStyles.type}>팔로워</div>
-            <div className={friendStyles.count}>
-              {profileData.followerCount}
-            </div>
-          </div>
-          <div className={friendStyles.item}>
-            <div className={friendStyles.type}>팔로잉</div>
-            <div className={friendStyles.count}>
-              {profileData.followingCount}
-            </div>
-          </div>
-        </div>
+        <ProfileContainer profileData={profileData} />
         <div className={buttonContainer}>
           <FollowButton />
         </div>
@@ -105,48 +85,6 @@ const profileContainer = flex({
   gap: '20px',
   padding: '20px',
 });
-
-const inforWrapper = flex({
-  alignItems: 'flex-start',
-  gap: '21px',
-  alignSelf: 'stretch',
-});
-
-const nameStyles = css({
-  textStyle: 'heading3',
-  fontWeight: '600',
-  color: 'text.normal',
-});
-
-const introStyles = css({
-  textStyle: 'body2.normal',
-  fontWeight: '500',
-  color: 'text.alternative',
-  width: '254px',
-});
-
-const friendStyles = {
-  container: flex({
-    alignItems: 'center',
-    gap: '40px',
-    alignSelf: 'stretch',
-  }),
-  item: flex({
-    direction: 'column',
-    alignItems: 'flex-start',
-    gap: '2px',
-  }),
-  type: css({
-    textStyle: 'label2',
-    fontWeight: '500',
-    color: 'text.alternative',
-  }),
-  count: css({
-    textStyle: 'body2.normal',
-    fontWeight: '600',
-    color: 'text.normal',
-  }),
-};
 
 const buttonContainer = flex({
   width: '100%',

--- a/features/profile/components/organisms/other-page.tsx
+++ b/features/profile/components/organisms/other-page.tsx
@@ -22,27 +22,33 @@ export function OtherPage({
   const [selectedTab, setSelectedTab] = useState<ProfileType>('statistics');
 
   return (
-    <section className={profileContainer}>
-      <div className={inforWrapper}>
-        <UserImageIcon />
-        <div>
-          <div className={nameStyles}>{profileData.nickname}</div>
-          <div className={introStyles}>{profileData.introduction}</div>
+    <div>
+      <section className={profileContainer}>
+        <div className={inforWrapper}>
+          <UserImageIcon />
+          <div>
+            <div className={nameStyles}>{profileData.nickname}</div>
+            <div className={introStyles}>{profileData.introduction}</div>
+          </div>
         </div>
-      </div>
-      <div className={friendStyles.container}>
-        <div className={friendStyles.item}>
-          <div className={friendStyles.type}>팔로워</div>
-          <div className={friendStyles.count}>{profileData.followerCount}</div>
+        <div className={friendStyles.container}>
+          <div className={friendStyles.item}>
+            <div className={friendStyles.type}>팔로워</div>
+            <div className={friendStyles.count}>
+              {profileData.followerCount}
+            </div>
+          </div>
+          <div className={friendStyles.item}>
+            <div className={friendStyles.type}>팔로잉</div>
+            <div className={friendStyles.count}>
+              {profileData.followingCount}
+            </div>
+          </div>
         </div>
-        <div className={friendStyles.item}>
-          <div className={friendStyles.type}>팔로잉</div>
-          <div className={friendStyles.count}>{profileData.followingCount}</div>
+        <div className={buttonContainer}>
+          <FollowButton />
         </div>
-      </div>
-      <div className={buttonContainer}>
-        <FollowButton />
-      </div>
+      </section>
       <Tab type="primary">
         <TabItem
           text="기록"
@@ -89,7 +95,7 @@ export function OtherPage({
           </div>
         </div>
       )}
-    </section>
+    </div>
   );
 }
 

--- a/features/profile/components/organisms/other-page.tsx
+++ b/features/profile/components/organisms/other-page.tsx
@@ -2,7 +2,6 @@
 
 import { useState } from 'react';
 
-import { ProfileProps } from '@/app/profile/[id]/page';
 import BadgeIcon from '@/components/atoms/icons/badge-icon';
 import StatisticsIcon from '@/components/atoms/icons/statistics-icon';
 import { Tab, TabItem } from '@/components/molecules';
@@ -11,6 +10,7 @@ import { css } from '@/styled-system/css';
 import { flex } from '@/styled-system/patterns';
 import { ProfileType } from '@/types/profileType';
 
+import { ProfileProps } from '../../types/profile';
 import FollowButton from '../atoms/follow-button';
 import ProfileContainer from './profile-container';
 

--- a/features/profile/components/organisms/profile-container.tsx
+++ b/features/profile/components/organisms/profile-container.tsx
@@ -1,7 +1,8 @@
-import { ProfileProps } from '@/app/profile/[id]/page';
 import { UserImageIcon } from '@/components/atoms/icons/user-image-icon';
 import { css } from '@/styled-system/css';
 import { flex } from '@/styled-system/patterns';
+
+import { ProfileProps } from '../../types/profile';
 
 export default function ProfileContainer({
   profileData,
@@ -47,7 +48,6 @@ const introStyles = css({
   textStyle: 'body2.normal',
   fontWeight: '500',
   color: 'text.alternative',
-  width: '254px',
 });
 
 const friendStyles = {

--- a/features/profile/components/organisms/profile-container.tsx
+++ b/features/profile/components/organisms/profile-container.tsx
@@ -1,0 +1,74 @@
+import { ProfileProps } from '@/app/profile/[id]/page';
+import { UserImageIcon } from '@/components/atoms/icons/user-image-icon';
+import { css } from '@/styled-system/css';
+import { flex } from '@/styled-system/patterns';
+
+export default function ProfileContainer({
+  profileData,
+}: {
+  profileData: ProfileProps['data'];
+}) {
+  return (
+    <>
+      <div className={inforWrapper}>
+        <UserImageIcon />
+        <div>
+          <div className={nameStyles}>{profileData.nickname}</div>
+          <div className={introStyles}>{profileData.introduction}</div>
+        </div>
+      </div>
+      <div className={friendStyles.container}>
+        <div className={friendStyles.item}>
+          <div className={friendStyles.type}>팔로워</div>
+          <div className={friendStyles.count}>{profileData.followerCount}</div>
+        </div>
+        <div className={friendStyles.item}>
+          <div className={friendStyles.type}>팔로잉</div>
+          <div className={friendStyles.count}>{profileData.followingCount}</div>
+        </div>
+      </div>
+    </>
+  );
+}
+
+const inforWrapper = flex({
+  alignItems: 'flex-start',
+  gap: '21px',
+  alignSelf: 'stretch',
+});
+
+const nameStyles = css({
+  textStyle: 'heading3',
+  fontWeight: '600',
+  color: 'text.normal',
+});
+
+const introStyles = css({
+  textStyle: 'body2.normal',
+  fontWeight: '500',
+  color: 'text.alternative',
+  width: '254px',
+});
+
+const friendStyles = {
+  container: flex({
+    alignItems: 'center',
+    gap: '40px',
+    alignSelf: 'stretch',
+  }),
+  item: flex({
+    direction: 'column',
+    alignItems: 'flex-start',
+    gap: '2px',
+  }),
+  type: css({
+    textStyle: 'label2',
+    fontWeight: '500',
+    color: 'text.alternative',
+  }),
+  count: css({
+    textStyle: 'body2.normal',
+    fontWeight: '600',
+    color: 'text.normal',
+  }),
+};

--- a/features/profile/index.ts
+++ b/features/profile/index.ts
@@ -1,1 +1,2 @@
 export * from './components';
+export * from './types/profile';

--- a/features/profile/types/profile.ts
+++ b/features/profile/types/profile.ts
@@ -1,0 +1,12 @@
+export interface ProfileProps {
+  status: number;
+  code: string;
+  data: {
+    memberId: number;
+    nickname: string;
+    isMyProfile: boolean;
+    followerCount: number;
+    followingCount: number;
+    introduction: string;
+  };
+}


### PR DESCRIPTION
<!-- 작성 예시 -->
<!-- # 어떤 문제가 발생했나요? -->
<!-- - 간략한 문제 설명 -->
<!-- - 문제 관련 링크 등등 -->
<!-- Ex) React v18 version update에 후 테스트에서 에러가 발생합니다.
  라이브러리의 버전이 호환이 되지않아서 문제입니다. -->

<!-- # 어떻게 해결했나요? -->
<!-- - 동작 방식 등 수정힌 코드에 대한 설명 -->
<!-- Ex) 라이브러리의 버전을 업데이트하고, v18을 사용할 수 있도록 dev dependency로 설치해주었습니다. -->

<!-- # 이미지 첨부 (Option) -->
<!-- - 이번 PR의 동작 이해를 돕는 GIF나 이미지 파일 첨부! -->
<!-- - 만약 없다면, NA 혹은 비워둡시다~ -->

<!-- # 유의할 점 (Option) -->
<!-- - 추가적으로 고민중이거나 조언을 구하고 싶은 내용, 어떤 것을 중점으로 리뷰를 해줬으면 좋겠는지 등등 작성 -->
<!-- - 만약 없다면, NA 혹은 비워둡시다~ -->

## 🤔 어떤 문제가 발생했나요?

- figma와 다르게 마이페이지 좌우 padding이 들어간 이슈가 있었습니다.
- GNB가 추가되었습니다.

## 🎉 어떻게 해결했나요?

- Tab 을 기준으로 위에만 좌우 padding이 들어가도록 div 태그로 랩핑했습니다.
- 마이페이지 공통 컴포넌트에 GNB를 추가했습니다.

### 📷 이미지 첨부 (Option)

<img width="1440" alt="image" src="https://github.com/user-attachments/assets/d5281111-aaf9-48c4-a560-edbbb9a8e8e1">


### ⚠️ 유의할 점! (Option)

-

<!-- PR merge시 닫을 이슈가 있다면, 번호를 작성해주세요 -->
<!-- Ex) close #12 -->
