### PR TITLE
fix: input의 type이 number일 때 자동으로 생기는 화살표 제거

### DIFF
--- a/components/molecules/text-field/text-field.tsx
+++ b/components/molecules/text-field/text-field.tsx
@@ -78,6 +78,17 @@ export function TextField({
                   : inputFieldStyles.raw({ isWritten: false }),
               ),
               className,
+              inputType === 'number' &&
+                css({
+                  '&::-webkit-outer-spin-button': {
+                    WebkitAppearance: 'none',
+                    margin: 0,
+                  },
+                  '&::-webkit-inner-spin-button': {
+                    WebkitAppearance: 'none',
+                    margin: 0,
+                  },
+                }),
             )}
           />
         }

--- a/components/molecules/text-field/text-field.tsx
+++ b/components/molecules/text-field/text-field.tsx
@@ -77,18 +77,8 @@ export function TextField({
                   ? inputFieldStyles.raw({ isWritten: true })
                   : inputFieldStyles.raw({ isWritten: false }),
               ),
+              inputType === 'number' && deleteArrowStyle,
               className,
-              inputType === 'number' &&
-                css({
-                  '&::-webkit-outer-spin-button': {
-                    WebkitAppearance: 'none',
-                    margin: 0,
-                  },
-                  '&::-webkit-inner-spin-button': {
-                    WebkitAppearance: 'none',
-                    margin: 0,
-                  },
-                }),
             )}
           />
         }
@@ -100,3 +90,10 @@ export function TextField({
     </TextFieldWrapper>
   );
 }
+
+const deleteArrowStyle = css({
+  '&::-webkit-inner-spin-button, &::-webkit-outer-spin-button': {
+    WebkitAppearance: 'none',
+    margin: 0,
+  },
+});


### PR DESCRIPTION
## 🤔 어떤 문제가 발생했나요?

- number type의 input에서 focus시, default로 화살표 디자인이 나타났습니다.

## 🎉 어떻게 해결했나요?

- 화살표를 삭제하는 css를 추가해주었습니다.

### 📷 이미지 첨부 (Option)

- before & after

<img width="209" alt="image" src="https://github.com/user-attachments/assets/87696e3c-2a83-40e4-abf5-e22904000f64">

<img width="429" alt="image" src="https://github.com/user-attachments/assets/70253914-da04-4a82-b303-24f8578ec5ed">

<img width="433" alt="image" src="https://github.com/user-attachments/assets/c661200b-e39e-493d-8aad-feb668611996">

### ⚠️ 유의할 점! (Option)

- NA
