### PR TITLE
chore: ios 에서 type number인 input 작성 시 숫자 키보드가 뜰 수 있게끔 설정

### DIFF
--- a/components/molecules/text-field/text-field.tsx
+++ b/components/molecules/text-field/text-field.tsx
@@ -65,6 +65,8 @@ export function TextField({
         {
           <input
             type={inputType}
+            inputMode={inputType === 'number' ? 'decimal' : undefined}
+            pattern={inputType === 'number' ? '[0-9]*' : undefined}
             value={value}
             placeholder={placeholder}
             maxLength={maxLength}


### PR DESCRIPTION
## 🤔 어떤 문제가 발생했나요?

- IOS에서 input type이 number일 경우에도 숫자 키보드가 뜨지 않았습니다.

## 🎉 어떻게 해결했나요?

- input 태그의 속성을 추가해주었습니다.

### 📷 이미지 첨부 (Option)

<img width="677" alt="image" src="https://github.com/user-attachments/assets/0c245ef3-f791-4461-a15a-a5f512e405bc">

### ⚠️ 유의할 점! (Option)

- NA
