### PR TITLE
chore: 수영 거리 페이지 모달에서 버튼에 safe-area 설정

### DIFF
--- a/features/record/components/organisms/distance-page-modal.tsx
+++ b/features/record/components/organisms/distance-page-modal.tsx
@@ -223,7 +223,7 @@ const layout = {
   button: css({
     w: 'full',
     position: 'absolute',
-    bottom: '15px',
+    bottom: 'calc(15px + env(safe-area-inset-bottom))',
     padding: '0 20px',
   }),
 };

--- a/features/record/components/organisms/distance-page-modal.tsx
+++ b/features/record/components/organisms/distance-page-modal.tsx
@@ -90,9 +90,14 @@ export function DistancePageModal({
   };
 
   const handleDoneButtonClick = () => {
-    if (secondaryTabIndex === 0 && assistiveTabIndex === 0)
-      setValue('totalDistance', totalMeter + 'm');
-    else setValue('totalDistance', totalStrokeDistance + 'm');
+    if (secondaryTabIndex === 0 && isAssistiveIndexZero) {
+      setValue('totalDistance', totalMeter ? totalMeter + 'm' : undefined);
+    } else {
+      setValue(
+        'totalDistance',
+        totalStrokeDistance ? totalStrokeDistance + 'm' : undefined,
+      );
+    }
     if (secondaryTabIndex === 0) {
       if (isAssistiveIndexZero) {
         if (totalMeter) {
@@ -130,6 +135,7 @@ export function DistancePageModal({
     }
     handlers.onClosePageModal();
   };
+
   return (
     <PageModal
       isOpen={pageModalState.isOpen}


### PR DESCRIPTION
## 🤔 어떤 문제가 발생했나요?


## 🎉 어떻게 해결했나요?

- 수영 거리 페이지 모달에서 버튼에 safe-area 관련 스타일로 설정해 주었습니다.

### 📷 이미지 첨부 (Option)

- NA

### ⚠️ 유의할 점! (Option)

- NA
