### PR TITLE
fix: 잘못된 영법별 시각화 색상 변경

### DIFF
--- a/constants/visualization.ts
+++ b/constants/visualization.ts
@@ -3,8 +3,8 @@ import { Strokes } from '@/features/main';
 export const swims: Array<{ name: keyof Strokes; color: string }> = [
   { name: '총거리', color: '#3B87F4' },
   { name: '자유형', color: '#3B87F4' },
-  { name: '평영', color: '#F3DD6E' },
-  { name: '배영', color: '#EB5A3F' },
-  { name: '접영', color: '#88D4B0' },
+  { name: '배영', color: '#F3DD6E' },
+  { name: '평영', color: '#88D4B0' },
+  { name: '접영', color: '#EB5A3F' },
   { name: '킥판', color: '#C383EA' },
 ];

--- a/features/main/components/time-line/atoms/swim-record-chart.tsx
+++ b/features/main/components/time-line/atoms/swim-record-chart.tsx
@@ -85,8 +85,8 @@ const nameStyles = cva({
     type: {
       자유형: { color: 'primary.swim.자유형.default' },
       배영: { color: 'primary.swim.배영.default' },
-      접영: { color: 'primary.swim.접영.default' },
       평영: { color: 'primary.swim.평영.default' },
+      접영: { color: 'primary.swim.접영.default' },
       킥판: { color: 'primary.swim.킥판.default' },
     },
   },

--- a/styles/colors.ts
+++ b/styles/colors.ts
@@ -90,11 +90,11 @@ export const semanticColors = {
         sub: { value: '#CDEAFF' },
       },
       배영: {
-        default: { value: '#58E06E' },
+        default: { value: '#FFCD1D' },
         sub: { value: '#AFF3BA' },
       },
       평영: {
-        default: { value: '#FFCD1D' },
+        default: { value: '#58E06E' },
         sub: { value: '#FFECAB' },
       },
       접영: {


### PR DESCRIPTION
<!-- 작성 예시 -->
<!-- # 어떤 문제가 발생했나요? -->
<!-- - 간략한 문제 설명 -->
<!-- - 문제 관련 링크 등등 -->
<!-- Ex) React v18 version update에 후 테스트에서 에러가 발생합니다.
  라이브러리의 버전이 호환이 되지않아서 문제입니다. -->

<!-- # 어떻게 해결했나요? -->
<!-- - 동작 방식 등 수정힌 코드에 대한 설명 -->
<!-- Ex) 라이브러리의 버전을 업데이트하고, v18을 사용할 수 있도록 dev dependency로 설치해주었습니다. -->

<!-- # 이미지 첨부 (Option) -->
<!-- - 이번 PR의 동작 이해를 돕는 GIF나 이미지 파일 첨부! -->
<!-- - 만약 없다면, NA 혹은 비워둡시다~ -->

<!-- # 유의할 점 (Option) -->
<!-- - 추가적으로 고민중이거나 조언을 구하고 싶은 내용, 어떤 것을 중점으로 리뷰를 해줬으면 좋겠는지 등등 작성 -->
<!-- - 만약 없다면, NA 혹은 비워둡시다~ -->

## 🤔 어떤 문제가 발생했나요?

- 영법별 색상이 잘못 기입되어 있었습니다.

## 🎉 어떻게 해결했나요?

- 피그마에 지정된 색상으로 수정하였습니다. (자유형 - 파랑/ 배영 - 노랑/ 평영 - 초록/  접영 - 빨강)

### 📷 이미지 첨부 (Option)

-

### ⚠️ 유의할 점! (Option)

-

<!-- PR merge시 닫을 이슈가 있다면, 번호를 작성해주세요 -->
<!-- Ex) close #12 -->
