### PR TITLE
feat: 당겨서 새로고침시 새롭게 소식 데이터를 불러오는 기능 추가

### DIFF
--- a/features/news/components/organisms/news-list.tsx
+++ b/features/news/components/organisms/news-list.tsx
@@ -13,16 +13,23 @@ import { NewsContent } from '../../types';
 import { EmptyNews, NewsItemWrapper, NewsItemWrapperProps } from '../molecules';
 import { FindMemberButton, FollowingListLinkButton } from '../atoms';
 import { useNewsData } from '../../hooks';
+import { useQueryClient } from '@tanstack/react-query';
 
 export const NewsList = () => {
   const ptrRef = useRef(null);
+  const queryClient = useQueryClient();
   const { data: newsData, fetchNextPage, hasNextPage } = useNewsData();
 
   if (!newsData) return null;
 
-  const contents = newsData.pages.flatMap(({ data }) => data.content);
+  let contents = newsData.pages.flatMap(({ data }) => data.content);
   const isEmpty = contents.length === 0;
   const lastItemIndex = contents.length - 1;
+
+  const handlePullToRefresh = () => {
+    queryClient.invalidateQueries({ queryKey: ['newsData'] });
+    queryClient.refetchQueries({ queryKey: ['newsData'], type: 'active' });
+  };
 
   return isEmpty ? (
     <section className={emptySectionStyle}>
@@ -40,10 +47,7 @@ export const NewsList = () => {
       </HeaderBar>
 
       <div className={sectionStyle} ref={ptrRef}>
-        <PullToRefresh
-          ref={ptrRef}
-          onRefresh={() => console.log('refreshing')}
-        />
+        <PullToRefresh ref={ptrRef} onRefresh={handlePullToRefresh} />
         <InfiniteScroller
           isLastPage={!hasNextPage}
           onIntersect={() => fetchNextPage()}


### PR DESCRIPTION
<!-- 작성 예시 -->
<!-- # 어떤 문제가 발생했나요? -->
<!-- - 간략한 문제 설명 -->
<!-- - 문제 관련 링크 등등 -->
<!-- Ex) React v18 version update에 후 테스트에서 에러가 발생합니다.
  라이브러리의 버전이 호환이 되지않아서 문제입니다. -->

<!-- # 어떻게 해결했나요? -->
<!-- - 동작 방식 등 수정힌 코드에 대한 설명 -->
<!-- Ex) 라이브러리의 버전을 업데이트하고, v18을 사용할 수 있도록 dev dependency로 설치해주었습니다. -->

<!-- # 이미지 첨부 (Option) -->
<!-- - 이번 PR의 동작 이해를 돕는 GIF나 이미지 파일 첨부! -->
<!-- - 만약 없다면, NA 혹은 비워둡시다~ -->

<!-- # 유의할 점 (Option) -->
<!-- - 추가적으로 고민중이거나 조언을 구하고 싶은 내용, 어떤 것을 중점으로 리뷰를 해줬으면 좋겠는지 등등 작성 -->
<!-- - 만약 없다면, NA 혹은 비워둡시다~ -->

## 🤔 어떤 문제가 발생했나요?

-

## 🎉 어떻게 해결했나요?

- 소식 페이지에서 당겨서 새로고침시 새롭게 소식 데이터를 불러오는 기능을 추가하였습니다.

### 📷 이미지 첨부 (Option)

https://github.com/user-attachments/assets/54216369-76c9-46a3-8cff-18d4d953bca6

### ⚠️ 유의할 점! (Option)

-

<!-- PR merge시 닫을 이슈가 있다면, 번호를 작성해주세요 -->
<!-- Ex) close #12 -->
