### PR TITLE
fix: 변경된 API 응답 필드 이름 수정

### DIFF
--- a/features/news/components/molecules/news-item-wrapper.tsx
+++ b/features/news/components/molecules/news-item-wrapper.tsx
@@ -11,7 +11,7 @@ export interface NewsItemWrapperProps {
   memberId: number;
   isRecentNews: boolean;
   profileUrl?: string;
-  memberNickName: string;
+  memberNickname: string;
   recordAt: string;
   createdAt: string;
   isLast?: boolean;
@@ -20,7 +20,7 @@ export interface NewsItemWrapperProps {
 export const NewsItemWrapper = ({
   isRecentNews,
   profileUrl,
-  memberNickName,
+  memberNickname,
   recordAt,
   createdAt,
   isLast,
@@ -40,7 +40,7 @@ export const NewsItemWrapper = ({
         </div>
         <div>
           <p className={descriptionStyles}>
-            <span className={nameStyle}>{memberNickName}</span>님이{' '}
+            <span className={nameStyle}>{memberNickname}</span>님이{' '}
             {`${month}월 ${day}일`}의 수영을 기록했어요.
           </p>
           <p className={postTimeStyles}>

--- a/features/news/components/organisms/news-list.tsx
+++ b/features/news/components/organisms/news-list.tsx
@@ -74,7 +74,7 @@ export const NewsList = () => {
 const getPropsObjects = (content: NewsContent) => {
   const {
     memberId,
-    memberNickName,
+    memberNickname,
     createdAt,
     isRecentNews,
     memoryId,
@@ -92,7 +92,7 @@ const getPropsObjects = (content: NewsContent) => {
 
   const wrapperProps: NewsItemWrapperProps = {
     memberId,
-    memberNickName,
+    memberNickname,
     createdAt,
     isRecentNews,
     recordAt,


### PR DESCRIPTION
<!-- 작성 예시 -->
<!-- # 어떤 문제가 발생했나요? -->
<!-- - 간략한 문제 설명 -->
<!-- - 문제 관련 링크 등등 -->
<!-- Ex) React v18 version update에 후 테스트에서 에러가 발생합니다.
  라이브러리의 버전이 호환이 되지않아서 문제입니다. -->

<!-- # 어떻게 해결했나요? -->
<!-- - 동작 방식 등 수정힌 코드에 대한 설명 -->
<!-- Ex) 라이브러리의 버전을 업데이트하고, v18을 사용할 수 있도록 dev dependency로 설치해주었습니다. -->

<!-- # 이미지 첨부 (Option) -->
<!-- - 이번 PR의 동작 이해를 돕는 GIF나 이미지 파일 첨부! -->
<!-- - 만약 없다면, NA 혹은 비워둡시다~ -->

<!-- # 유의할 점 (Option) -->
<!-- - 추가적으로 고민중이거나 조언을 구하고 싶은 내용, 어떤 것을 중점으로 리뷰를 해줬으면 좋겠는지 등등 작성 -->
<!-- - 만약 없다면, NA 혹은 비워둡시다~ -->

## 🤔 어떤 문제가 발생했나요?

- API 필드 이름이 바뀌어 소식 페이지에 기록자 이름이 나오지 않았습니다.

## 🎉 어떻게 해결했나요?

- API에 맞게 필드 이름을 수정하였습니다.

### 📷 이미지 첨부 (Option)

![image](https://github.com/user-attachments/assets/97792a86-9fd7-44d4-925a-20c53b08fe51)

### ⚠️ 유의할 점! (Option)

-

<!-- PR merge시 닫을 이슈가 있다면, 번호를 작성해주세요 -->
<!-- Ex) close #12 -->
