### PR TITLE
feat: 소식 페이지 헤더 API 연결

### DIFF
--- a/app/api/friend/following/summary/route.ts
+++ b/app/api/friend/following/summary/route.ts
@@ -1,0 +1,13 @@
+import { NextResponse } from 'next/server';
+
+import { fetchData } from '@/apis/fetch-data';
+import { FollowingSummaryResponse } from '@/features/news';
+
+export async function GET() {
+  const data = await fetchData<FollowingSummaryResponse>(
+    '/friend/following/summary',
+    'GET',
+  );
+
+  return NextResponse.json(data);
+}

--- a/features/news/components/atoms/following-list-link-button.tsx
+++ b/features/news/components/atoms/following-list-link-button.tsx
@@ -5,44 +5,22 @@ import { DefaultProfileIcon, Image, PersonsIcon } from '@/components/atoms';
 import { css, cx } from '@/styled-system/css';
 import { flex } from '@/styled-system/patterns';
 
-interface FollowingInfo {
-  memberId: number;
-  name: string;
-  introduction: string;
-  profileUrl?: string;
-}
-
-const dummy: { followings: Array<FollowingInfo>; followingCount: number } = {
-  followings: [
-    {
-      memberId: 1,
-      name: '홍길동',
-      introduction: '안녕하세요. 홍길동입니다',
-    },
-    {
-      memberId: 2,
-      name: '홍길동',
-      introduction: '안녕하세요. 홍길동입니다',
-    },
-    {
-      memberId: 3,
-      name: '홍길동',
-      introduction: '안녕하세요. 홍길동입니다',
-    },
-  ],
-  followingCount: 12,
-};
+import { useFollowingSummary } from '../../hooks';
 
 const MAX_NUMBER_OF_PROFILES = 3;
 
 export const FollowingListLinkButton = () => {
-  const { followings, followingCount } = dummy;
+  const { data: followingSummaryData } = useFollowingSummary();
+
+  if (!followingSummaryData) return null;
+
+  const { followings, followingCount } = followingSummaryData.data;
   const hasFollowings = followingCount > 0;
   const indexOffset = MAX_NUMBER_OF_PROFILES - followings.length;
   let nodeList: Array<ReactNode> = [];
 
   if (hasFollowings) {
-    nodeList = followings.map(({ memberId, profileUrl }, index) => (
+    nodeList = followings.map(({ memberId, profileImageUrl }, index) => (
       <div
         key={memberId}
         className={cx(
@@ -51,8 +29,13 @@ export const FollowingListLinkButton = () => {
           profileStyles[index + indexOffset],
         )}
       >
-        {profileUrl ? (
-          <Image src={profileUrl} alt="following profiles" />
+        {profileImageUrl ? (
+          <Image
+            src={profileImageUrl}
+            alt="following profiles"
+            width={24}
+            height={24}
+          />
         ) : (
           <DefaultProfileIcon width={24} height={24} />
         )}
@@ -95,22 +78,23 @@ const borderStyles = css({
   borderColor: 'white',
 });
 
-const baseProfileStyle = css({
+const baseProfileStyle = flex({
   position: 'absolute',
   top: '2px',
-  borderRadius: 'full',
   backgroundColor: 'white',
+  overflow: 'hidden',
 });
 
 const profileStyles = [
-  css({ right: '-96px' }),
-  css({ right: '-80px' }),
-  css({ right: '-64px' }),
+  css({ right: '-98px' }),
+  css({ right: '-82px' }),
+  css({ right: '-66px' }),
 ];
 
 const countStyles = css({
-  w: '14px',
+  w: '16px',
   h: '16px',
+  textAlign: 'center',
   textStyle: 'caption1',
   fontWeight: 'bold',
   color: 'primary.swim.총거리.default',

--- a/features/news/hooks/index.ts
+++ b/features/news/hooks/index.ts
@@ -1,1 +1,2 @@
+export * from './use-following-summary';
 export * from './use-news-data';

--- a/features/news/hooks/use-following-summary.ts
+++ b/features/news/hooks/use-following-summary.ts
@@ -1,0 +1,22 @@
+import { keepPreviousData, useQuery } from '@tanstack/react-query';
+
+import { FollowingSummaryResponse } from '../types';
+
+const getFollowingSummary = async () => {
+  const res = await fetch('/api/friend/following/summary', {
+    method: 'GET',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+  });
+
+  return res.json();
+};
+
+export const useFollowingSummary = () => {
+  return useQuery<FollowingSummaryResponse>({
+    queryKey: ['followingSummary'],
+    queryFn: () => getFollowingSummary(),
+    placeholderData: keepPreviousData,
+  });
+};

--- a/features/news/types/index.ts
+++ b/features/news/types/index.ts
@@ -1,4 +1,5 @@
 import { Response } from '@/apis';
+import { ProfileFollowContent } from '@/features/follow';
 import { TimeLineContent } from '@/features/main';
 
 import { NewsItemWrapperProps } from '../components';
@@ -11,3 +12,10 @@ export type NewsResponse = Response<{
   cursorId: number;
   hasNext: boolean;
 }>;
+
+export interface FolowingSummaryData {
+  followings: Array<ProfileFollowContent>;
+  followingCount: number;
+}
+
+export type FollowingSummaryResponse = Response<FolowingSummaryData>;


### PR DESCRIPTION
<!-- 작성 예시 -->
<!-- # 어떤 문제가 발생했나요? -->
<!-- - 간략한 문제 설명 -->
<!-- - 문제 관련 링크 등등 -->
<!-- Ex) React v18 version update에 후 테스트에서 에러가 발생합니다.
  라이브러리의 버전이 호환이 되지않아서 문제입니다. -->

<!-- # 어떻게 해결했나요? -->
<!-- - 동작 방식 등 수정힌 코드에 대한 설명 -->
<!-- Ex) 라이브러리의 버전을 업데이트하고, v18을 사용할 수 있도록 dev dependency로 설치해주었습니다. -->

<!-- # 이미지 첨부 (Option) -->
<!-- - 이번 PR의 동작 이해를 돕는 GIF나 이미지 파일 첨부! -->
<!-- - 만약 없다면, NA 혹은 비워둡시다~ -->

<!-- # 유의할 점 (Option) -->
<!-- - 추가적으로 고민중이거나 조언을 구하고 싶은 내용, 어떤 것을 중점으로 리뷰를 해줬으면 좋겠는지 등등 작성 -->
<!-- - 만약 없다면, NA 혹은 비워둡시다~ -->

## 🤔 어떤 문제가 발생했나요?

-

## 🎉 어떻게 해결했나요?

- 소식 페이지 헤더 부분의 팔로잉 목록 이동 버튼에 API를 활용하여 데이터를 보여주도록 수정하였습니다.

### 📷 이미지 첨부 (Option)

-

### ⚠️ 유의할 점! (Option)

-

<!-- PR merge시 닫을 이슈가 있다면, 번호를 작성해주세요 -->
<!-- Ex) close #12 -->
