### PR TITLE
feat: 소식 페이지 리스트 아이템의 프로필 이미지 클릭시 해당 유저 페이지로 이동

### DIFF
--- a/features/news/components/molecules/news-item-wrapper.tsx
+++ b/features/news/components/molecules/news-item-wrapper.tsx
@@ -1,3 +1,4 @@
+import Link from 'next/link';
 import { PropsWithChildren } from 'react';
 
 import { DefaultProfileIcon, Image } from '@/components/atoms';
@@ -18,6 +19,7 @@ export interface NewsItemWrapperProps {
 }
 
 export const NewsItemWrapper = ({
+  memberId,
   isRecentNews,
   profileUrl,
   memberNickname,
@@ -30,14 +32,17 @@ export const NewsItemWrapper = ({
   return (
     <li className={cx(containerStyles, isLast ? emptyStyle : lastItemStyles)}>
       <div className={userInfoStyles}>
-        <div className={userProfileImageWrapperStyles}>
+        <Link
+          href={`/profile/${memberId}`}
+          className={userProfileImageWrapperStyles}
+        >
           {isRecentNews && <div className={newMarkStyles} />}
           {profileUrl ? (
             <Image src={profileUrl} alt="user profile image" />
           ) : (
             <DefaultProfileIcon width={40} height={40} />
           )}
-        </div>
+        </Link>
         <div>
           <p className={descriptionStyles}>
             <span className={nameStyle}>{memberNickname}</span>님이{' '}


### PR DESCRIPTION
<!-- 작성 예시 -->
<!-- # 어떤 문제가 발생했나요? -->
<!-- - 간략한 문제 설명 -->
<!-- - 문제 관련 링크 등등 -->
<!-- Ex) React v18 version update에 후 테스트에서 에러가 발생합니다.
  라이브러리의 버전이 호환이 되지않아서 문제입니다. -->

<!-- # 어떻게 해결했나요? -->
<!-- - 동작 방식 등 수정힌 코드에 대한 설명 -->
<!-- Ex) 라이브러리의 버전을 업데이트하고, v18을 사용할 수 있도록 dev dependency로 설치해주었습니다. -->

<!-- # 이미지 첨부 (Option) -->
<!-- - 이번 PR의 동작 이해를 돕는 GIF나 이미지 파일 첨부! -->
<!-- - 만약 없다면, NA 혹은 비워둡시다~ -->

<!-- # 유의할 점 (Option) -->
<!-- - 추가적으로 고민중이거나 조언을 구하고 싶은 내용, 어떤 것을 중점으로 리뷰를 해줬으면 좋겠는지 등등 작성 -->
<!-- - 만약 없다면, NA 혹은 비워둡시다~ -->

## 🤔 어떤 문제가 발생했나요?

-

## 🎉 어떻게 해결했나요?

- 소식 페이지의 아이템 중 프로필 이미지 클릭시 해당 유저 페이지로 이동하도록 수정하였습니다.

### 📷 이미지 첨부 (Option)

-

### ⚠️ 유의할 점! (Option)

-

<!-- PR merge시 닫을 이슈가 있다면, 번호를 작성해주세요 -->
<!-- Ex) close #12 -->
