### PR TITLE
feat: 소식 페이지 헤더중 팔로잉 목록 이동 버튼을 위한 API 추가

### DIFF
--- a/app/api/friend/following/summary/route.ts
+++ b/app/api/friend/following/summary/route.ts
@@ -1,0 +1,13 @@
+import { NextResponse } from 'next/server';
+
+import { fetchData } from '@/apis/fetch-data';
+import { FollowingSummaryResponse } from '@/features/news';
+
+export async function GET() {
+  const data = await fetchData<FollowingSummaryResponse>(
+    '/friend/following/summary',
+    'GET',
+  );
+
+  return NextResponse.json(data);
+}

--- a/features/news/components/atoms/following-list-link-button.tsx
+++ b/features/news/components/atoms/following-list-link-button.tsx
@@ -1,7 +1,8 @@
 import Link from 'next/link';
 import { ReactNode } from 'react';
 
-import { DefaultProfileIcon, Image, PersonsIcon } from '@/components/atoms';
+import { DefaultProfileIcon, PersonsIcon } from '@/components/atoms';
+import { ProfileImage } from '@/components/molecules';
 import { css, cx } from '@/styled-system/css';
 import { flex } from '@/styled-system/patterns';
 
@@ -30,11 +31,14 @@ export const FollowingListLinkButton = () => {
         )}
       >
         {profileImageUrl ? (
-          <Image
+          <ProfileImage
             src={profileImageUrl}
             alt="following profiles"
-            width={24}
-            height={24}
+            width={28}
+            height={28}
+            style={{
+              objectFit: 'cover',
+            }}
           />
         ) : (
           <DefaultProfileIcon width={24} height={24} />
@@ -81,7 +85,11 @@ const borderStyles = css({
 const baseProfileStyle = flex({
   position: 'absolute',
   top: '2px',
+  width: '28px',
+  height: '28px',
   backgroundColor: 'white',
+  align: 'stretch',
+  rounded: 'full',
   overflow: 'hidden',
 });
 

--- a/features/news/components/atoms/following-list-link-button.tsx
+++ b/features/news/components/atoms/following-list-link-button.tsx
@@ -5,44 +5,22 @@ import { DefaultProfileIcon, Image, PersonsIcon } from '@/components/atoms';
 import { css, cx } from '@/styled-system/css';
 import { flex } from '@/styled-system/patterns';
 
-interface FollowingInfo {
-  memberId: number;
-  name: string;
-  introduction: string;
-  profileUrl?: string;
-}
-
-const dummy: { followings: Array<FollowingInfo>; followingCount: number } = {
-  followings: [
-    {
-      memberId: 1,
-      name: '홍길동',
-      introduction: '안녕하세요. 홍길동입니다',
-    },
-    {
-      memberId: 2,
-      name: '홍길동',
-      introduction: '안녕하세요. 홍길동입니다',
-    },
-    {
-      memberId: 3,
-      name: '홍길동',
-      introduction: '안녕하세요. 홍길동입니다',
-    },
-  ],
-  followingCount: 12,
-};
+import { useFollowingSummary } from '../../hooks';
 
 const MAX_NUMBER_OF_PROFILES = 3;
 
 export const FollowingListLinkButton = () => {
-  const { followings, followingCount } = dummy;
+  const { data: followingSummaryData } = useFollowingSummary();
+
+  if (!followingSummaryData) return null;
+
+  const { followings, followingCount } = followingSummaryData.data;
   const hasFollowings = followingCount > 0;
   const indexOffset = MAX_NUMBER_OF_PROFILES - followings.length;
   let nodeList: Array<ReactNode> = [];
 
   if (hasFollowings) {
-    nodeList = followings.map(({ memberId, profileUrl }, index) => (
+    nodeList = followings.map(({ memberId, profileImageUrl }, index) => (
       <div
         key={memberId}
         className={cx(
@@ -51,8 +29,13 @@ export const FollowingListLinkButton = () => {
           profileStyles[index + indexOffset],
         )}
       >
-        {profileUrl ? (
-          <Image src={profileUrl} alt="following profiles" />
+        {profileImageUrl ? (
+          <Image
+            src={profileImageUrl}
+            alt="following profiles"
+            width={24}
+            height={24}
+          />
         ) : (
           <DefaultProfileIcon width={24} height={24} />
         )}
@@ -95,22 +78,23 @@ const borderStyles = css({
   borderColor: 'white',
 });
 
-const baseProfileStyle = css({
+const baseProfileStyle = flex({
   position: 'absolute',
   top: '2px',
-  borderRadius: 'full',
   backgroundColor: 'white',
+  overflow: 'hidden',
 });
 
 const profileStyles = [
-  css({ right: '-96px' }),
-  css({ right: '-80px' }),
-  css({ right: '-64px' }),
+  css({ right: '-98px' }),
+  css({ right: '-82px' }),
+  css({ right: '-66px' }),
 ];
 
 const countStyles = css({
-  w: '14px',
+  w: '16px',
   h: '16px',
+  textAlign: 'center',
   textStyle: 'caption1',
   fontWeight: 'bold',
   color: 'primary.swim.총거리.default',

--- a/features/news/components/atoms/following-list-link-button.tsx
+++ b/features/news/components/atoms/following-list-link-button.tsx
@@ -16,12 +16,9 @@ export const FollowingListLinkButton = () => {
   if (!followingSummaryData) return null;
 
   const { followings, followingCount } = followingSummaryData.data;
-  const hasFollowings = followingCount > 0;
   const indexOffset = MAX_NUMBER_OF_PROFILES - followings.length;
-  let nodeList: Array<ReactNode> = [];
-
-  if (hasFollowings) {
-    nodeList = followings.map(({ memberId, profileImageUrl }, index) => (
+  const nodeList: Array<ReactNode> = [
+    ...followings.map(({ memberId, profileImageUrl }, index) => (
       <div
         key={memberId}
         className={cx(
@@ -44,8 +41,8 @@ export const FollowingListLinkButton = () => {
           <DefaultProfileIcon width={24} height={24} />
         )}
       </div>
-    ));
-  }
+    )),
+  ];
 
   nodeList.push(
     <div key="follower-count" className={cx(containerStyles, borderStyles)}>

--- a/features/news/components/molecules/news-item-wrapper.tsx
+++ b/features/news/components/molecules/news-item-wrapper.tsx
@@ -11,7 +11,7 @@ import { CheerUpButton } from '../atoms';
 export interface NewsItemWrapperProps {
   memberId: number;
   isRecentNews: boolean;
-  memberProfileUrl?: string;
+  profileImageUrl?: string;
   memberNickname: string;
   recordAt: string;
   createdAt: string;
@@ -20,7 +20,7 @@ export interface NewsItemWrapperProps {
 
 export const NewsItemWrapper = ({
   isRecentNews,
-  memberProfileUrl,
+  profileImageUrl,
   memberNickname,
   recordAt,
   createdAt,
@@ -33,9 +33,9 @@ export const NewsItemWrapper = ({
       <div className={userInfoStyles}>
         <div className={userProfileImageWrapperStyles}>
           {isRecentNews && <div className={newMarkStyles} />}
-          {memberProfileUrl ? (
+          {profileImageUrl ? (
             <ProfileImage
-              src={memberProfileUrl}
+              src={profileImageUrl}
               alt="user profile image"
               width={40}
               height={40}

--- a/features/news/components/molecules/news-item-wrapper.tsx
+++ b/features/news/components/molecules/news-item-wrapper.tsx
@@ -1,6 +1,7 @@
 import { PropsWithChildren } from 'react';
 
-import { DefaultProfileIcon, Image } from '@/components/atoms';
+import { DefaultProfileIcon } from '@/components/atoms';
+import { ProfileImage } from '@/components/molecules';
 import { css, cx } from '@/styled-system/css';
 import { flex } from '@/styled-system/patterns';
 import { convertTimeToElapsedTime, getFormatDate } from '@/utils';
@@ -10,7 +11,7 @@ import { CheerUpButton } from '../atoms';
 export interface NewsItemWrapperProps {
   memberId: number;
   isRecentNews: boolean;
-  profileUrl?: string;
+  memberProfileUrl?: string;
   memberNickname: string;
   recordAt: string;
   createdAt: string;
@@ -19,7 +20,7 @@ export interface NewsItemWrapperProps {
 
 export const NewsItemWrapper = ({
   isRecentNews,
-  profileUrl,
+  memberProfileUrl,
   memberNickname,
   recordAt,
   createdAt,
@@ -32,8 +33,16 @@ export const NewsItemWrapper = ({
       <div className={userInfoStyles}>
         <div className={userProfileImageWrapperStyles}>
           {isRecentNews && <div className={newMarkStyles} />}
-          {profileUrl ? (
-            <Image src={profileUrl} alt="user profile image" />
+          {memberProfileUrl ? (
+            <ProfileImage
+              src={memberProfileUrl}
+              alt="user profile image"
+              width={40}
+              height={40}
+              style={{
+                objectFit: 'cover',
+              }}
+            />
           ) : (
             <DefaultProfileIcon width={40} height={40} />
           )}
@@ -69,7 +78,13 @@ const userInfoStyles = flex({
   alignItems: 'center',
 });
 
-const userProfileImageWrapperStyles = css({ width: '40px', height: '40px' });
+const userProfileImageWrapperStyles = flex({
+  width: '40px',
+  height: '40px',
+  align: 'stretch',
+  rounded: 'full',
+  overflow: 'hidden',
+});
 
 const newMarkStyles = css({
   position: 'absolute',

--- a/features/news/components/organisms/news-list.tsx
+++ b/features/news/components/organisms/news-list.tsx
@@ -75,6 +75,7 @@ const getPropsObjects = (content: NewsContent) => {
   const {
     memberId,
     memberNickname,
+    memberProfileUrl,
     createdAt,
     isRecentNews,
     memoryId,
@@ -93,6 +94,7 @@ const getPropsObjects = (content: NewsContent) => {
   const wrapperProps: NewsItemWrapperProps = {
     memberId,
     memberNickname,
+    memberProfileUrl,
     createdAt,
     isRecentNews,
     recordAt,

--- a/features/news/components/organisms/news-list.tsx
+++ b/features/news/components/organisms/news-list.tsx
@@ -75,7 +75,7 @@ const getPropsObjects = (content: NewsContent) => {
   const {
     memberId,
     memberNickname,
-    memberProfileUrl,
+    profileImageUrl,
     createdAt,
     isRecentNews,
     memoryId,
@@ -94,7 +94,7 @@ const getPropsObjects = (content: NewsContent) => {
   const wrapperProps: NewsItemWrapperProps = {
     memberId,
     memberNickname,
-    memberProfileUrl,
+    profileImageUrl,
     createdAt,
     isRecentNews,
     recordAt,

--- a/features/news/hooks/index.ts
+++ b/features/news/hooks/index.ts
@@ -1,1 +1,2 @@
+export * from './use-following-summary';
 export * from './use-news-data';

--- a/features/news/hooks/use-following-summary.ts
+++ b/features/news/hooks/use-following-summary.ts
@@ -1,0 +1,22 @@
+import { keepPreviousData, useQuery } from '@tanstack/react-query';
+
+import { FollowingSummaryResponse } from '../types';
+
+const getFollowingSummary = async () => {
+  const res = await fetch('/api/friend/following/summary', {
+    method: 'GET',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+  });
+
+  return res.json();
+};
+
+export const useFollowingSummary = () => {
+  return useQuery<FollowingSummaryResponse>({
+    queryKey: ['followingSummary'],
+    queryFn: () => getFollowingSummary(),
+    placeholderData: keepPreviousData,
+  });
+};

--- a/features/news/types/index.ts
+++ b/features/news/types/index.ts
@@ -1,5 +1,6 @@
 import { Response } from '@/apis';
 import { TimeLineContent } from '@/features/main';
+import { MemberProfile } from '@/types';
 
 import { NewsItemWrapperProps } from '../components';
 
@@ -11,3 +12,10 @@ export type NewsResponse = Response<{
   cursorId: number;
   hasNext: boolean;
 }>;
+
+export interface FolowingSummaryData {
+  followings: Array<MemberProfile>;
+  followingCount: number;
+}
+
+export type FollowingSummaryResponse = Response<FolowingSummaryData>;


### PR DESCRIPTION
<!-- 작성 예시 -->
<!-- # 어떤 문제가 발생했나요? -->
<!-- - 간략한 문제 설명 -->
<!-- - 문제 관련 링크 등등 -->
<!-- Ex) React v18 version update에 후 테스트에서 에러가 발생합니다.
  라이브러리의 버전이 호환이 되지않아서 문제입니다. -->

<!-- # 어떻게 해결했나요? -->
<!-- - 동작 방식 등 수정힌 코드에 대한 설명 -->
<!-- Ex) 라이브러리의 버전을 업데이트하고, v18을 사용할 수 있도록 dev dependency로 설치해주었습니다. -->

<!-- # 이미지 첨부 (Option) -->
<!-- - 이번 PR의 동작 이해를 돕는 GIF나 이미지 파일 첨부! -->
<!-- - 만약 없다면, NA 혹은 비워둡시다~ -->

<!-- # 유의할 점 (Option) -->
<!-- - 추가적으로 고민중이거나 조언을 구하고 싶은 내용, 어떤 것을 중점으로 리뷰를 해줬으면 좋겠는지 등등 작성 -->
<!-- - 만약 없다면, NA 혹은 비워둡시다~ -->

## 🤔 어떤 문제가 발생했나요?

- 헤더 및 아이템들의 프로필 이미지가 정상적으로 나타나지 않아 

## 🎉 어떻게 해결했나요?

- 소식 페이지 헤더의 팔로잉 목록 이동 버튼에 API를 연결하였습니다.
- 헤더 및 아이템들의 프로필 이미지가 정상적으로 나타날 수 있도록 필드명을 수정하고 css 속성을 추가하여 적용하였습니다.

### 📷 이미지 첨부 (Option)

![스크린샷 2024-08-29 오전 2 26 44](https://github.com/user-attachments/assets/3712ba9b-0bc2-44c0-9bdc-6079f01aa2a3)

### ⚠️ 유의할 점! (Option)

-

<!-- PR merge시 닫을 이슈가 있다면, 번호를 작성해주세요 -->
<!-- Ex) close #12 -->
