### PR TITLE
fix: introduction 타입 옵셔널로 수정

### DIFF
--- a/features/profile/components/organisms/profile-edit-form.tsx
+++ b/features/profile/components/organisms/profile-edit-form.tsx
@@ -80,7 +80,7 @@ export function ProfileEditForm() {
     if (data.nickname?.trim() === profileData?.nickname.trim()) {
       delete modifiedData.nickname;
     }
-    if (data.introduction?.trim() === profileData?.introduction.trim()) {
+    if (data.introduction?.trim() === profileData?.introduction?.trim()) {
       delete modifiedData.introduction;
     }
 

--- a/features/profile/types/profile.ts
+++ b/features/profile/types/profile.ts
@@ -7,7 +7,7 @@ export interface ProfileProps {
     isMyProfile: boolean;
     followerCount: number;
     followingCount: number;
-    introduction: string;
+    introduction?: string;
     profileImageUrl: string;
   };
 }


### PR DESCRIPTION
## 🤔 어떤 문제가 발생했나요?


## 🎉 어떻게 해결했나요?

- introduction의 타입을 옵셔널로 수정 후, trim 함수를 수행하는 과정에서 예외처리를 추가하였습니다.

### 📷 이미지 첨부 (Option)

- NA

### ⚠️ 유의할 점! (Option)

- NA
