### PR TITLE
fix: 수영 거리 기록 버그 수정

### DIFF
--- a/features/record/apis/use-pull-edit-memory.ts
+++ b/features/record/apis/use-pull-edit-memory.ts
@@ -19,6 +19,7 @@ export function usePullEditMemory(memoryId: number) {
     queryKey: ['usePullEditMemory', memoryId],
     queryFn: () => pullEditMemory(memoryId),
     retry: 1,
+    gcTime: 0,
     enabled: !!memoryId,
   });
 }

--- a/features/record/components/organisms/form.tsx
+++ b/features/record/components/organisms/form.tsx
@@ -139,7 +139,7 @@ export function Form() {
 
   //Todo: 기록 에러 발생 시 처리
   const onSubmit: SubmitHandler<RecordRequestProps> = async (data) => {
-    if (isLoading) return;
+    if (isLoading || !startTime || !endTime) return;
     //기록 수정 모드일 때
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     const { poolName, laneMeter, totalDistance, ...restData } = data;
@@ -294,7 +294,11 @@ export function Form() {
       </form>
       <LaneLengthBottomSheet title="레인 길이를 선택해주세요" />
       <PoolSearchPageModal title="어디서 수영했나요?" />
-      <DistancePageModal defaultStrokes={data?.data.strokes} />
+      <DistancePageModal
+        defaultStrokes={data?.data.strokes}
+        defaultTotalLap={data?.data.totalLap}
+        defaultTotalMeter={data?.data.totalMeter}
+      />
       <TimeBottomSheet />
     </FormProvider>
   );

--- a/features/record/hooks/use-distance-page-modal.tsx
+++ b/features/record/hooks/use-distance-page-modal.tsx
@@ -200,7 +200,7 @@ export function useDistancePageModal<T>(
   const buttonLabel =
     secondaryTabIndex === 0 && assistiveTabIndex === 0
       ? '완료'
-      : `${totalStrokeDistance ? totalStrokeDistance + 'm' : ''} 완료`;
+      : `${totalStrokeDistance ? totalStrokeDistance + 'm' : ''} 수영 완료`;
 
   return {
     pageModalRef,

--- a/features/record/hooks/use-distance-page-modal.tsx
+++ b/features/record/hooks/use-distance-page-modal.tsx
@@ -10,7 +10,7 @@ import { StrokeProps } from '../types';
 
 type tabIndex = 0 | 1;
 
-//Todo: 상태들 리팩토링 & 각 로직들 리팩토링
+//Todo: 코드 개선
 export function useDistancePageModal<T>(
   lane: number,
   defaultStrokes?: StrokeProps[],
@@ -74,15 +74,22 @@ export function useDistancePageModal<T>(
         setTotalLaps(String(defaultTotalLap));
       } else {
         if (
-          defaultStrokes.every((stroke) => stroke.laps) &&
+          defaultStrokes.every((stroke) => Boolean(stroke.laps)) &&
           !formSubInfo.isDistanceLapModified
         )
           setFormSubInfo((prev) => ({ ...prev, isDistanceLapModified: true }));
         defaultStrokes.forEach((strokes) => {
-          setStrokes((prev) => [
-            ...prev,
-            (prev[strokeOptions.indexOf(strokes.name)] = strokes),
-          ]);
+          const index = strokeOptions.indexOf(strokes.name);
+          setStrokes((prev) => {
+            const updatedStrokes = [...prev];
+            updatedStrokes[index] = {
+              ...updatedStrokes[index],
+              laps: strokes.laps,
+              meter: strokes.meter,
+            };
+
+            return updatedStrokes;
+          });
         });
       }
       setTotalStrokeDistance(defaultTotalMeter as number);
@@ -193,7 +200,7 @@ export function useDistancePageModal<T>(
   const buttonLabel =
     secondaryTabIndex === 0 && assistiveTabIndex === 0
       ? '완료'
-      : `${totalStrokeDistance ? totalStrokeDistance + 'm' : ''} 수영 완료`;
+      : `${totalStrokeDistance ? totalStrokeDistance + 'm' : ''} 완료`;
 
   return {
     pageModalRef,


### PR DESCRIPTION
## 🤔 어떤 문제가 발생했나요?

- 전달되지 않은 props가 있었습니다.

- 예를 들어 영법별 기록의 바퀴 수를 4개 입력했던 기록에서 -> 영법별 기록의 미터 수를 3개 입력으로 수정 후 -> 다시 수정 페이지로 접근하여 보면 처음의 바퀴 수 기록이 일부 남아있는 버그가 있었습니다.

## 🎉 어떻게 해결했나요?

- props를 전달해주었습니다

- gcTime을 0으로 설정해주어 캐시된 데이터가 미리 보여짐으로써 useEffect가 두번 실행되는 현상을 수정하였습니다.

### 📷 이미지 첨부 (Option)

- NA

### ⚠️ 유의할 점! (Option)

- NA
