### PR TITLE
fix: 바퀴 수로 기록시 타임라인 차트가 뜨지 않는 현상 수정

### DIFF
--- a/constants/visualization.ts
+++ b/constants/visualization.ts
@@ -2,6 +2,7 @@ import { Strokes } from '@/features/main';
 
 export const swims: Array<{ name: keyof Strokes; color: string }> = [
   { name: '총거리', color: '#3B87F4' },
+  { name: '총바퀴', color: '#3B87F4' },
   { name: '자유형', color: '#3B87F4' },
   { name: '배영', color: '#F3DD6E' },
   { name: '평영', color: '#88D4B0' },

--- a/features/main/types/calendar.ts
+++ b/features/main/types/calendar.ts
@@ -4,6 +4,7 @@ export type MemoryType = 'NORMAL' | 'SINGLE' | 'MULTI';
 
 export interface Strokes {
   총거리?: number;
+  총바퀴?: number;
   자유형?: number;
   평영?: number;
   배영?: number;


### PR DESCRIPTION
<!-- 작성 예시 -->
<!-- # 어떤 문제가 발생했나요? -->
<!-- - 간략한 문제 설명 -->
<!-- - 문제 관련 링크 등등 -->
<!-- Ex) React v18 version update에 후 테스트에서 에러가 발생합니다.
  라이브러리의 버전이 호환이 되지않아서 문제입니다. -->

<!-- # 어떻게 해결했나요? -->
<!-- - 동작 방식 등 수정힌 코드에 대한 설명 -->
<!-- Ex) 라이브러리의 버전을 업데이트하고, v18을 사용할 수 있도록 dev dependency로 설치해주었습니다. -->

<!-- # 이미지 첨부 (Option) -->
<!-- - 이번 PR의 동작 이해를 돕는 GIF나 이미지 파일 첨부! -->
<!-- - 만약 없다면, NA 혹은 비워둡시다~ -->

<!-- # 유의할 점 (Option) -->
<!-- - 추가적으로 고민중이거나 조언을 구하고 싶은 내용, 어떤 것을 중점으로 리뷰를 해줬으면 좋겠는지 등등 작성 -->
<!-- - 만약 없다면, NA 혹은 비워둡시다~ -->

## 🤔 어떤 문제가 발생했나요?

- 바퀴 수로만 총 거리를 입력시 타임라인 카드의 차트가 뜨지 않았습니다.

## 🎉 어떻게 해결했나요?

- `총바퀴` 타입을 추가하였습니다.

### 📷 이미지 첨부 (Option)

-

### ⚠️ 유의할 점! (Option)

-

<!-- PR merge시 닫을 이슈가 있다면, 번호를 작성해주세요 -->
<!-- Ex) close #12 -->
