### PR TITLE
refactor: use prevent scroll import 위치 변경

### DIFF
--- a/components/molecules/cheer/cheer-bottom-sheet.tsx
+++ b/components/molecules/cheer/cheer-bottom-sheet.tsx
@@ -1,7 +1,6 @@
 import { Button } from '@/components/atoms';
 import { BottomSheet, BottomSheetProps } from '@/components/molecules';
 import { DetailCheerItemSelected } from '@/features/record-detail';
-import { usePreventBodyScroll } from '@/hooks';
 import { flex, grid } from '@/styled-system/patterns';
 
 import { CheerItem } from './cheer-item';
@@ -19,8 +18,6 @@ export const CheerBottomSheet = ({
   onClickCheerItem,
   onClickSendCheer,
 }: CheerBottomSheet) => {
-  usePreventBodyScroll({ isOpen });
-
   return (
     <BottomSheet header={header} isOpen={isOpen} onClose={onClose}>
       <div className={tagContainerStyle}>

--- a/components/molecules/cheer/cheer-progress.tsx
+++ b/components/molecules/cheer/cheer-progress.tsx
@@ -116,6 +116,7 @@ const content = {
     textStyle: 'heading4',
     fontWeight: 'bold',
     color: 'text.normal',
+    width: 'max-content',
 
     '& > span': {
       ml: '8px',

--- a/hooks/use-cheer-bottom-sheet.ts
+++ b/hooks/use-cheer-bottom-sheet.ts
@@ -3,7 +3,7 @@
 import { useState } from 'react';
 
 import { DetailCheerItemSelected } from '@/features/record-detail';
-import { useCheer, useCheerEligibility } from '@/hooks';
+import { useCheer, useCheerEligibility, usePreventBodyScroll } from '@/hooks';
 
 import { useToast } from './use-toast';
 
@@ -55,17 +55,18 @@ export const useCheerBottomSheet = ({
   onSuccessCheer,
   isIncludeVerification,
 }: UseCheerBottomSheet) => {
+  const [isOpenBottomSheet, setIsOpenBottomSheet] = useState(false);
+  const [cheerList, setCheerList] = useState(initialCheerList);
+  const [selectedCheerItem, setSelectedCheerItem] =
+    useState<DetailCheerItemSelected>();
+
   const { mutate: mutateCheer } = useCheer();
   const { data: eligibilityData, refetch: refetchCheerEligibility } =
     useCheerEligibility(
       memoryId,
       isIncludeVerification && isIncludeVerification?.isMyMemory,
     );
-
-  const [isOpenBottomSheet, setIsOpenBottomSheet] = useState(false);
-  const [cheerList, setCheerList] = useState(initialCheerList);
-  const [selectedCheerItem, setSelectedCheerItem] =
-    useState<DetailCheerItemSelected>();
+  usePreventBodyScroll({ isOpen: isOpenBottomSheet });
 
   const { toast } = useToast();
 


### PR DESCRIPTION
<!-- 작성 예시 -->
<!-- # 어떤 문제가 발생했나요? -->
<!-- - 간략한 문제 설명 -->
<!-- - 문제 관련 링크 등등 -->
<!-- Ex) React v18 version update에 후 테스트에서 에러가 발생합니다.
  라이브러리의 버전이 호환이 되지않아서 문제입니다. -->

<!-- # 어떻게 해결했나요? -->
<!-- - 동작 방식 등 수정힌 코드에 대한 설명 -->
<!-- Ex) 라이브러리의 버전을 업데이트하고, v18을 사용할 수 있도록 dev dependency로 설치해주었습니다. -->

<!-- # 이미지 첨부 (Option) -->
<!-- - 이번 PR의 동작 이해를 돕는 GIF나 이미지 파일 첨부! -->
<!-- - 만약 없다면, NA 혹은 비워둡시다~ -->

<!-- # 유의할 점 (Option) -->
<!-- - 추가적으로 고민중이거나 조언을 구하고 싶은 내용, 어떤 것을 중점으로 리뷰를 해줬으면 좋겠는지 등등 작성 -->
<!-- - 만약 없다면, NA 혹은 비워둡시다~ -->

## 🤔 어떤 문제가 발생했나요?

-

## 🎉 어떻게 해결했나요?

- usePreventScroll 혹을 바텀시트 컴포넌트 > 훅 내부로 옮깁니다

### 📷 이미지 첨부 (Option)

-

### ⚠️ 유의할 점! (Option)

-

<!-- PR merge시 닫을 이슈가 있다면, 번호를 작성해주세요 -->
<!-- Ex) close #12 -->
