### PR TITLE
chore: 기록 후 다음 기록 시 이전 기록에 있던 사진이 그대로 올라가는 현상 수정

### DIFF
--- a/features/record/components/organisms/form.tsx
+++ b/features/record/components/organisms/form.tsx
@@ -92,9 +92,6 @@ export function Form() {
           ? prevData.totalMeter.toLocaleString() + 'm'
           : undefined,
       });
-      setFormSubInfo({
-        imageFiles: [],
-      });
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [data]);
@@ -133,6 +130,10 @@ export function Form() {
     router.replace(
       `/record/success?editMode=true&memoryId=${Number(memoryId)}`,
     );
+    setFormSubInfo({
+      imageFiles: [],
+      isDistanceLapModified: false,
+    });
   };
 
   const handleRecordMakeSuccess = (memoryRes: {
@@ -144,6 +145,10 @@ export function Form() {
     router.replace(
       `/record/success?rank=${memoryRes.rank}&memoryId=${memoryRes.memoryId}&month=${memoryRes.month}`,
     );
+    setFormSubInfo({
+      imageFiles: [],
+      isDistanceLapModified: false,
+    });
   };
 
   //Todo: 기록 에러 발생 시 처리


### PR DESCRIPTION
## 🤔 어떤 문제가 발생했나요?

- 기록 후, 다음 기록 시 이전 기록의 사진이 그대로 올라가는 현상이 있었습니다.

## 🎉 어떻게 해결했나요?

- 전역 상태로 관리하는 사진 File을 통신 성공 시, reset 해주었습니다.

### 📷 이미지 첨부 (Option)

- NA

### ⚠️ 유의할 점! (Option)

- NA
