### PR TITLE
fix: 사파리에서 브라우저 PTR Disable

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -6,7 +6,7 @@ import dynamic from 'next/dynamic';
 import Script from 'next/script';
 
 import MetaTagImage from '@/public/images/meta-tag.png';
-import { css } from '@/styled-system/css';
+import { css, cx } from '@/styled-system/css';
 import { pretendard } from '@/styles/font';
 
 import ReactQueryProvider from './providers/ReactQueryProvider';
@@ -58,7 +58,7 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="ko" className={pretendard.className}>
+    <html lang="ko" className={cx(pretendard.className, htmlStyles)}>
       <body className={rootStyle}>
         <ReactQueryProvider>
           <ReactQueryDevtools initialIsOpen={true} />
@@ -73,6 +73,9 @@ export default function RootLayout({
     </html>
   );
 }
+
+// NOTE: Disable Safari Pull to Refresh
+const htmlStyles = css({ overflow: 'hidden', overscrollBehavior: 'none' });
 
 const containerStyle = css({
   minHeight: '100%',


### PR DESCRIPTION
<!-- 작성 예시 -->
<!-- # 어떤 문제가 발생했나요? -->
<!-- - 간략한 문제 설명 -->
<!-- - 문제 관련 링크 등등 -->
<!-- Ex) React v18 version update에 후 테스트에서 에러가 발생합니다.
  라이브러리의 버전이 호환이 되지않아서 문제입니다. -->

<!-- # 어떻게 해결했나요? -->
<!-- - 동작 방식 등 수정힌 코드에 대한 설명 -->
<!-- Ex) 라이브러리의 버전을 업데이트하고, v18을 사용할 수 있도록 dev dependency로 설치해주었습니다. -->

<!-- # 이미지 첨부 (Option) -->
<!-- - 이번 PR의 동작 이해를 돕는 GIF나 이미지 파일 첨부! -->
<!-- - 만약 없다면, NA 혹은 비워둡시다~ -->

<!-- # 유의할 점 (Option) -->
<!-- - 추가적으로 고민중이거나 조언을 구하고 싶은 내용, 어떤 것을 중점으로 리뷰를 해줬으면 좋겠는지 등등 작성 -->
<!-- - 만약 없다면, NA 혹은 비워둡시다~ -->

## 🤔 어떤 문제가 발생했나요?

- iOS 사파리 브라우저에서 기본적으로 PTR을 제공하여 구현한 PTR이 동작하지 않았습니다.

## 🎉 어떻게 해결했나요?

- 사파리의 PTR을 disable하기 위해 overscroll을 없앴습니다.

### 📷 이미지 첨부 (Option)

-

### ⚠️ 유의할 점! (Option)

-

<!-- PR merge시 닫을 이슈가 있다면, 번호를 작성해주세요 -->
<!-- Ex) close #12 -->
