### PR TITLE
fix: 기록 수정 버그 백엔드와 타입 조정 후 수정

### DIFF
--- a/features/record/components/organisms/form.tsx
+++ b/features/record/components/organisms/form.tsx
@@ -75,16 +75,16 @@ export function Form() {
         poolId: prevData?.pool?.id ? prevData.pool.id : undefined,
         poolName: prevData?.pool?.name ? prevData.pool.name : undefined,
         diary: prevData.diary ? prevData.diary : undefined,
-        heartRate: prevData.memoryDetail.heartRate
+        heartRate: prevData.memoryDetail?.heartRate
           ? prevData.memoryDetail.heartRate
           : undefined,
-        paceMinutes: prevData.memoryDetail.paceMinutes
+        paceMinutes: prevData.memoryDetail?.paceMinutes
           ? prevData.memoryDetail.paceMinutes
           : undefined,
-        paceSeconds: prevData.memoryDetail.paceSeconds
+        paceSeconds: prevData.memoryDetail?.paceSeconds
           ? prevData.memoryDetail.paceSeconds
           : undefined,
-        kcal: prevData.memoryDetail.kcal
+        kcal: prevData.memoryDetail?.kcal
           ? prevData.memoryDetail.kcal
           : undefined,
         strokes: prevData.strokes ? prevData.strokes : undefined,
@@ -301,7 +301,7 @@ export function Form() {
         <Divider variant="thick" />
         <EquipmentSection
           title="장비"
-          defaultEquipment={data?.data.memoryDetail.item}
+          defaultEquipment={data?.data.memoryDetail?.item}
         />
         <Divider variant="thick" />
         <SubInfoSection title="심박수 · 페이스 · 칼로리" />


### PR DESCRIPTION
## 🤔 어떤 문제가 발생했나요?

- 기록 수정에서 빈 값으로 필드를 보낼 시, 해당 필드가 빈 값으로 반영되지 않았습니다.

## 🎉 어떻게 해결했나요?

- 백엔드와 토의를 통해 타입을 재정의 하고, undefined로 수정 요청을 보낼 시에도 해당 필드를 빈 값으로 수정해주었습니다.

### 📷 이미지 첨부 (Option)

- NA

### ⚠️ 유의할 점! (Option)

- NA

