### PR TITLE
refactor: 알림 페이지의 무한스크롤을 Virtuoso로 변경합니다.

### DIFF
--- a/features/notification/apis/use-get-notification.tsx
+++ b/features/notification/apis/use-get-notification.tsx
@@ -32,12 +32,10 @@ export function useGetNotification() {
     });
   const { fetchNextPage, isFetchingNextPage } = queryInfo;
 
-  const rawNotificationData =
-    data?.pages.map((page) => page.data.notifications).flat() || [];
   const getByFarNotificationData: (
     | CheerNotificationProps
     | FollowNotificationProps
-  )[] = rawNotificationData;
+  )[] = data?.pages.map((page) => page.data.notifications).flat() || [];
 
   const lastPageCount = data?.pages.length ?? 0;
   const lastMemberIdList = useMemo(

--- a/features/notification/apis/use-get-notification.tsx
+++ b/features/notification/apis/use-get-notification.tsx
@@ -1,8 +1,7 @@
 'use client';
 
 import { useInfiniteQuery } from '@tanstack/react-query';
-import { useEffect, useMemo } from 'react';
-import { useInView } from 'react-intersection-observer';
+import { useMemo } from 'react';
 
 import { useMemberFollowingState } from '@/hooks';
 
@@ -31,18 +30,7 @@ export function useGetNotification() {
       getNextPageParam: (lastPage) =>
         lastPage.data.hasNext ? lastPage.data.cursorCreatedAt : undefined,
     });
-  const { hasNextPage, fetchNextPage, isFetchingNextPage } = queryInfo;
-
-  const { ref, inView } = useInView({
-    rootMargin: '100px 0px 0px 0px',
-  });
-
-  useEffect(() => {
-    if (inView) {
-      // eslint-disable-next-line @typescript-eslint/no-floating-promises
-      hasNextPage && fetchNextPage();
-    }
-  }, [inView, hasNextPage, fetchNextPage]);
+  const { fetchNextPage, isFetchingNextPage } = queryInfo;
 
   const rawNotificationData =
     data?.pages.map((page) => page.data.notifications).flat() || [];
@@ -65,5 +53,10 @@ export function useGetNotification() {
   const { useSyncFollowingListState } = useMemberFollowingState();
   useSyncFollowingListState(lastMemberIdList);
 
-  return { ref, isLoading, isFetchingNextPage, getByFarNotificationData };
+  return {
+    isLoading,
+    fetchNextPage,
+    isFetchingNextPage,
+    getByFarNotificationData,
+  };
 }

--- a/features/notification/components/molecules/cheer-notification.tsx
+++ b/features/notification/components/molecules/cheer-notification.tsx
@@ -1,5 +1,5 @@
 import Link from 'next/link';
-import React, { forwardRef } from 'react';
+import React from 'react';
 
 import { css } from '@/styled-system/css';
 import {
@@ -12,56 +12,42 @@ import { layoutStyles, textStyles } from '../../styles';
 import { CheerNotificationProps } from '../../types';
 import { CheerUpIcon } from '../atoms';
 
-export const CheerNotification = forwardRef<
-  HTMLLIElement,
-  CheerNotificationProps & { assignRef: boolean }
->(
-  (
-    {
-      type,
-      notificationId,
-      nickname,
-      memoryId,
-      content,
-      createdAt,
-      recordCreatedAt,
-      hasRead,
-      assignRef,
-    },
-    ref,
-  ) => {
-    const { mutate: readNotification } = useReadNotification();
+export function CheerNotification({
+  notificationId,
+  type,
+  memoryId,
+  hasRead,
+  recordCreatedAt,
+  nickname,
+  content,
+  createdAt,
+}: CheerNotificationProps) {
+  const { mutate: readNotification } = useReadNotification();
 
-    const handleListElementClick = () => {
-      readNotification({ notificationId, type });
-    };
+  const handleListElementClick = () => {
+    readNotification({ notificationId, type });
+  };
 
-    return (
-      <Link href={`record-detail/${memoryId}`} onClick={handleListElementClick}>
-        <li
-          ref={assignRef ? ref : undefined}
-          className={css(layoutStyles.total.raw({ hasRead }))}
-        >
-          <CheerUpIcon />
-          <div className={css(layoutStyles.text.raw({ type }))}>
-            {type === 'CHEER' && (
-              <>
-                <p className={textStyles.main}>
-                  {formatDateToKoreanExceptYear(recordCreatedAt)} 기록에{' '}
-                  <span className={textStyles.userName}>{nickname}</span>
-                  님이 응원을 남겼어요.
-                </p>
-                <p className={textStyles.description}>{`"${content} "`}</p>
-              </>
-            )}
-            <span className={textStyles.time}>
-              {convertTimeToElapsedTime(createdAt)}
-            </span>
-          </div>
-        </li>
-      </Link>
-    );
-  },
-);
-
-CheerNotification.displayName = 'CheerNotification';
+  return (
+    <Link href={`record-detail/${memoryId}`} onClick={handleListElementClick}>
+      <li className={css(layoutStyles.total.raw({ hasRead }))}>
+        <CheerUpIcon />
+        <div className={css(layoutStyles.text.raw({ type }))}>
+          {type === 'CHEER' && (
+            <>
+              <p className={textStyles.main}>
+                {formatDateToKoreanExceptYear(recordCreatedAt)} 기록에{' '}
+                <span className={textStyles.userName}>{nickname}</span>
+                님이 응원을 남겼어요.
+              </p>
+              <p className={textStyles.description}>{`"${content} "`}</p>
+            </>
+          )}
+          <span className={textStyles.time}>
+            {convertTimeToElapsedTime(createdAt)}
+          </span>
+        </div>
+      </li>
+    </Link>
+  );
+}

--- a/features/notification/components/molecules/follow-notification.tsx
+++ b/features/notification/components/molecules/follow-notification.tsx
@@ -1,5 +1,5 @@
 import Link from 'next/link';
-import React, { forwardRef } from 'react';
+import React from 'react';
 
 import { Button } from '@/components/atoms';
 import { ProfileImage } from '@/components/molecules';
@@ -11,101 +11,86 @@ import { useReadNotification } from '../../apis/use-read-notification';
 import { layoutStyles, textStyles } from '../../styles';
 import { FollowNotificationProps } from '../../types';
 
-export const FollowNotification = forwardRef<
-  HTMLLIElement,
-  FollowNotificationProps & { assignRef: boolean }
->(
-  (
-    {
-      type,
-      notificationId,
-      nickname,
-      profileImageUrl,
-      memberId,
-      createdAt,
-      hasRead,
-      assignRef,
-    },
-    ref,
-  ) => {
-    const { useMemberIsFollowing, toggleFollow } = useMemberFollowingState();
-    const { isFollowing } = useMemberIsFollowing(memberId);
-    const { mutate: readNotification } = useReadNotification();
+export function FollowNotification({
+  memberId,
+  notificationId,
+  type,
+  hasRead,
+  profileImageUrl,
+  nickname,
+  createdAt,
+}: FollowNotificationProps) {
+  const { useMemberIsFollowing, toggleFollow } = useMemberFollowingState();
+  const { isFollowing } = useMemberIsFollowing(memberId);
+  const { mutate: readNotification } = useReadNotification();
 
-    const handleListElementClick = () => {
-      readNotification({ notificationId, type });
-    };
+  const handleListElementClick = () => {
+    readNotification({ notificationId, type });
+  };
 
-    const handleFollowButtonClick = () => {
-      void toggleFollow(memberId);
-    };
+  const handleFollowButtonClick = () => {
+    void toggleFollow(memberId);
+  };
 
-    return (
-      <li
-        ref={assignRef ? ref : undefined}
-        className={css(layoutStyles.total.raw({ hasRead }))}
+  return (
+    <li className={css(layoutStyles.total.raw({ hasRead }))}>
+      <Link
+        href={`/profile/${memberId}`}
+        onClick={handleListElementClick}
+        className={css({ display: 'flex' })}
       >
-        <Link
-          href={`/profile/${memberId}`}
-          onClick={handleListElementClick}
-          className={css({ display: 'flex' })}
-        >
-          <div className={profileImageStyles}>
-            <ProfileImage
-              alt="프로필 사진"
-              src={profileImageUrl ?? ''}
-              fill
-              sizes="20vw"
-              className={css({ borderRadius: 'full', objectFit: 'cover' })}
-            />
-          </div>
-          <div className={css(layoutStyles.text.raw({ type }))}>
-            {type === 'FRIEND' && (
-              <p className={textStyles.main}>
-                <span className={textStyles.userName}>{nickname}</span>님과
-                친구가 되었어요!
-              </p>
-            )}
-            {type === 'FOLLOW' && (
-              <p className={textStyles.main}>
-                <span className={textStyles.userName}>{nickname}</span>님을
-                아시나요?{' '}
-                <span className={textStyles.userName}>{nickname}</span>
-                님이 나를 팔로우했어요.
-              </p>
-            )}
-            <span className={textStyles.time}>
-              {convertTimeToElapsedTime(createdAt)}
-            </span>
-          </div>
-        </Link>
+        <div className={profileImageStyles}>
+          <ProfileImage
+            alt="프로필 사진"
+            src={profileImageUrl ?? ''}
+            fill
+            sizes="20vw"
+            className={css({ borderRadius: 'full', objectFit: 'cover' })}
+          />
+        </div>
+        <div className={css(layoutStyles.text.raw({ type }))}>
+          {type === 'FRIEND' && (
+            <p className={textStyles.main}>
+              <span className={textStyles.userName}>{nickname}</span>님과 친구가
+              되었어요!
+            </p>
+          )}
+          {type === 'FOLLOW' && (
+            <p className={textStyles.main}>
+              <span className={textStyles.userName}>{nickname}</span>님을
+              아시나요? <span className={textStyles.userName}>{nickname}</span>
+              님이 나를 팔로우했어요.
+            </p>
+          )}
+          <span className={textStyles.time}>
+            {convertTimeToElapsedTime(createdAt)}
+          </span>
+        </div>
+      </Link>
 
-        {type === 'FOLLOW' &&
-          (isFollowing ? (
-            <Button
-              size="small"
-              label="팔로잉"
-              variant="outlined"
-              buttonType="assistive"
-              className={css(followButtonStyles.raw({ isFollowing }))}
-              onClick={handleFollowButtonClick}
-            />
-          ) : (
-            <Button
-              size="small"
-              label="팔로우"
-              variant="outlined"
-              buttonType="primary"
-              className={css(followButtonStyles.raw({ isFollowing }))}
-              onClick={handleFollowButtonClick}
-            />
-          ))}
-      </li>
-    );
-  },
-);
-
-FollowNotification.displayName = 'FollowNotification';
+      {type === 'FOLLOW' &&
+        (isFollowing ? (
+          <Button
+            size="small"
+            label="팔로잉"
+            variant="outlined"
+            buttonType="assistive"
+            className={css(followButtonStyles.raw({ isFollowing }))}
+            onClick={handleFollowButtonClick}
+          />
+        ) : (
+          <Button
+            size="small"
+            label="팔로우"
+            variant="outlined"
+            buttonType="primary"
+            className={css(followButtonStyles.raw({ isFollowing }))}
+            onClick={handleFollowButtonClick}
+          />
+        ))}
+    </li>
+  );
+}
 
 const followButtonStyles = cva({
   base: {

--- a/features/notification/components/organisms/notification-list.tsx
+++ b/features/notification/components/organisms/notification-list.tsx
@@ -28,13 +28,13 @@ export function NotificationList() {
   if (isLoading) return <NotificationListSkeleton />;
   return (
     <ol className={layoutStyles}>
-      {!isLoading && getByFarNotificationData.length === 0 && (
+      {getByFarNotificationData.length === 0 && (
         <NoNotification
           mainText="아직 받은 알림이 없어요"
           subText="공지, 활동 소식이 도착하면 알려드릴게요"
         />
       )}
-      {!isLoading && getByFarNotificationData.length > 0 && (
+      {getByFarNotificationData.length > 0 && (
         <Virtuoso
           data={getByFarNotificationData}
           overscan={200}

--- a/features/notification/components/organisms/notification-list.tsx
+++ b/features/notification/components/organisms/notification-list.tsx
@@ -34,29 +34,35 @@ export function NotificationList() {
           subText="공지, 활동 소식이 도착하면 알려드릴게요"
         />
       )}
-      <Virtuoso
-        data={getByFarNotificationData}
-        overscan={200}
-        useWindowScroll
-        rangeChanged={handleRangeChanged}
-        itemContent={(_, notification) =>
-          'memoryId' in notification ? (
-            <CheerNotification
-              key={notification.notificationId}
-              {...notification}
-            />
-          ) : (
-            <FollowNotification
-              key={notification.notificationId}
-              {...notification}
-            />
-          )
-        }
-        components={{
-          Footer: () =>
-            isFetchingNextPage ? <LoadingArea width={30} height={30} /> : <></>,
-        }}
-      />
+      {!isLoading && getByFarNotificationData.length > 0 && (
+        <Virtuoso
+          data={getByFarNotificationData}
+          overscan={200}
+          useWindowScroll
+          rangeChanged={handleRangeChanged}
+          itemContent={(_, notification) =>
+            'memoryId' in notification ? (
+              <CheerNotification
+                key={notification.notificationId}
+                {...notification}
+              />
+            ) : (
+              <FollowNotification
+                key={notification.notificationId}
+                {...notification}
+              />
+            )
+          }
+          components={{
+            Footer: () =>
+              isFetchingNextPage ? (
+                <LoadingArea width={30} height={30} />
+              ) : (
+                <></>
+              ),
+          }}
+        />
+      )}
     </ol>
   );
 }

--- a/features/record/apis/use-search-pool.ts
+++ b/features/record/apis/use-search-pool.ts
@@ -42,9 +42,8 @@ export default function useSearchPool(nameQuery: string) {
     }
   }, [inView, hasNextPage, fetchNextPage]);
 
-  const rawPoolData =
+  const getByFarPoolData: PoolProps[] =
     data?.pages.map((page) => page.data.poolInfos).flat() || [];
-  const getByFarPoolData: PoolProps[] = rawPoolData;
 
   return { ref, isLoading, isFetchingNextPage, getByFarPoolData };
 }


### PR DESCRIPTION
## 🤔 어떤 문제가 발생했나요?

- 알림 페이지에서는 데이터의 크기가 무한대로 늘어날 수 있습니다.

- 추후 알림 개수가 많아질 시, 굳이 그려지지 않아도 될 엘리먼트들까지 그려짐으로써 성능적인 측면에서 매우 큰 영향을 받을 수 있습니다.

## 🎉 어떻게 해결했나요?

- Virtuoso를 활용한 리스트 가상화를 통해 불필요한 엘리먼트들을 DOM에서 제거하였습니다.

### 📷 이미지 첨부 (Option)

- before( 알림 개수 33개 기준 )

![image](https://github.com/user-attachments/assets/01cc33ed-6780-41f1-83d2-9c9c6f57252e)

- after( 알림 개수 33개 기준 )

![image](https://github.com/user-attachments/assets/f58d2703-17ba-474e-9ce1-dc3a8642ce2b)


### ⚠️ 유의할 점! (Option)

- NA
