### PR TITLE
chore: 마이너스 기호 입력 방지 및 maxLength 설정

### DIFF
--- a/components/molecules/text-field/form-text-field.tsx
+++ b/components/molecules/text-field/form-text-field.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { ChangeEvent, forwardRef } from 'react';
+import React, { ChangeEvent, forwardRef, KeyboardEvent } from 'react';
 
 import { css, cx } from '@/styled-system/css';
 
@@ -65,6 +65,12 @@ export const FormTextField = forwardRef<HTMLInputElement, FormTextFieldProps>(
       } else void onChange(event);
     };
 
+    const handleKeyDown = (event: KeyboardEvent<HTMLInputElement>) => {
+      if (event.key === '-') {
+        event.preventDefault();
+      }
+    };
+
     return (
       <TextFieldWrapper
         isRequired={isRequired}
@@ -81,6 +87,7 @@ export const FormTextField = forwardRef<HTMLInputElement, FormTextFieldProps>(
             maxLength={maxLength}
             onFocus={() => handlers.onChangeFocus(true)}
             onBlur={() => handlers.onChangeFocus(false)}
+            onKeyDown={inputType === 'number' ? handleKeyDown : undefined}
             onChange={handleInputChange}
             className={cx(
               css(

--- a/components/molecules/text-field/form-text-field.tsx
+++ b/components/molecules/text-field/form-text-field.tsx
@@ -1,9 +1,9 @@
 'use client';
 
-import React, { ChangeEvent, forwardRef } from 'react';
+import React, { ChangeEvent, forwardRef, KeyboardEvent } from 'react';
 
 import { css, cx } from '@/styled-system/css';
-import { preventMinus } from '@/utils';
+import { preventCharacters } from '@/utils';
 
 import {
   absoluteStyles,
@@ -43,6 +43,7 @@ export const FormTextField = forwardRef<HTMLInputElement, FormTextFieldProps>(
       subText,
       placeholder,
       unit,
+      preventDecimal,
       className,
       maxLength,
       wrapperClassName,
@@ -66,6 +67,10 @@ export const FormTextField = forwardRef<HTMLInputElement, FormTextFieldProps>(
       } else void onChange(event);
     };
 
+    const handleKeyDown = (event: KeyboardEvent<HTMLInputElement>) => {
+      preventCharacters(event, ['-', preventDecimal ? '.' : '']);
+    };
+
     return (
       <TextFieldWrapper
         isRequired={isRequired}
@@ -82,7 +87,7 @@ export const FormTextField = forwardRef<HTMLInputElement, FormTextFieldProps>(
             maxLength={maxLength}
             onFocus={() => handlers.onChangeFocus(true)}
             onBlur={() => handlers.onChangeFocus(false)}
-            onKeyDown={inputType === 'number' ? preventMinus : undefined}
+            onKeyDown={inputType === 'number' ? handleKeyDown : undefined}
             onChange={handleInputChange}
             className={cx(
               css(

--- a/components/molecules/text-field/form-text-field.tsx
+++ b/components/molecules/text-field/form-text-field.tsx
@@ -1,8 +1,9 @@
 'use client';
 
-import React, { ChangeEvent, forwardRef, KeyboardEvent } from 'react';
+import React, { ChangeEvent, forwardRef } from 'react';
 
 import { css, cx } from '@/styled-system/css';
+import { preventMinus } from '@/utils';
 
 import {
   absoluteStyles,
@@ -65,12 +66,6 @@ export const FormTextField = forwardRef<HTMLInputElement, FormTextFieldProps>(
       } else void onChange(event);
     };
 
-    const handleKeyDown = (event: KeyboardEvent<HTMLInputElement>) => {
-      if (event.key === '-') {
-        event.preventDefault();
-      }
-    };
-
     return (
       <TextFieldWrapper
         isRequired={isRequired}
@@ -87,7 +82,7 @@ export const FormTextField = forwardRef<HTMLInputElement, FormTextFieldProps>(
             maxLength={maxLength}
             onFocus={() => handlers.onChangeFocus(true)}
             onBlur={() => handlers.onChangeFocus(false)}
-            onKeyDown={inputType === 'number' ? handleKeyDown : undefined}
+            onKeyDown={inputType === 'number' ? preventMinus : undefined}
             onChange={handleInputChange}
             className={cx(
               css(

--- a/components/molecules/text-field/text-field.tsx
+++ b/components/molecules/text-field/text-field.tsx
@@ -3,6 +3,7 @@
 import { ChangeEvent } from 'react';
 
 import { css, cx } from '@/styled-system/css';
+import { preventMinus } from '@/utils';
 
 import {
   absoluteStyles,
@@ -49,9 +50,13 @@ export function TextField({
 
   const shouldEmphasize = isWritten || focused;
 
-  const handleInputChange = (e: ChangeEvent<HTMLInputElement>) => {
-    const newText = e.target.value;
-    onChange?.(newText);
+  const handleInputChange = (event: ChangeEvent<HTMLInputElement>) => {
+    let newValue = event.target.value;
+
+    if (maxLength && newValue.length >= maxLength) {
+      newValue = newValue.slice(0, maxLength);
+      void onChange?.(newValue);
+    } else void onChange?.(newValue);
   };
 
   return (
@@ -73,6 +78,7 @@ export function TextField({
             onChange={handleInputChange}
             onFocus={() => handlers.onChangeFocus(true)}
             onBlur={() => handlers.onChangeFocus(false)}
+            onKeyDown={inputType === 'number' ? preventMinus : undefined}
             className={cx(
               css(
                 shouldEmphasize

--- a/components/molecules/text-field/type.ts
+++ b/components/molecules/text-field/type.ts
@@ -10,6 +10,8 @@ export interface TextFieldProps {
   placeholder?: string;
   unit?: string;
   maxLength?: number;
+  step?: number;
+  preventDecimal?: boolean;
   className?: string;
   wrapperClassName?: string;
   absoluteClassName?: string;

--- a/features/record/components/molecules/distance-field-with-badge.tsx
+++ b/features/record/components/molecules/distance-field-with-badge.tsx
@@ -47,6 +47,8 @@ export function DistanceFieldWithBadge({
       <TextField
         inputType="number"
         maxLength={isAssistiveTabIndexZero ? 5 : 3}
+        step={isAssistiveTabIndexZero ? undefined : 0.5}
+        preventDecimal={isAssistiveTabIndexZero}
         placeholder="0"
         value={value ? String(value) : ''}
         unit={unit}

--- a/features/record/components/molecules/distance-field-with-badge.tsx
+++ b/features/record/components/molecules/distance-field-with-badge.tsx
@@ -32,7 +32,8 @@ export function DistanceFieldWithBadge({
   className,
   onChangeStroke,
 }: DistanceFieldWithBadgeProps) {
-  const unit = assistiveTabIndex === 0 ? 'm' : '바퀴';
+  const isAssistiveTabIndexZero = assistiveTabIndex === 0;
+  const unit = isAssistiveTabIndexZero ? 'm' : '바퀴';
 
   const handleStrokeFieldChange = (text: string) => {
     onChangeStroke?.(index, text);
@@ -45,6 +46,7 @@ export function DistanceFieldWithBadge({
       </div>
       <TextField
         inputType="number"
+        maxLength={isAssistiveTabIndexZero ? 5 : 3}
         placeholder="0"
         value={value ? String(value) : ''}
         unit={unit}

--- a/features/record/components/organisms/distance-page-modal.tsx
+++ b/features/record/components/organisms/distance-page-modal.tsx
@@ -182,6 +182,7 @@ export function DistancePageModal({
                   ? '레인 길이에 따라 자동으로 거리를 계산해드릴게요'
                   : undefined
               }
+              maxLength={isAssistiveIndexOne ? 3 : 5}
               value={isAssistiveIndexZero ? totalMeter : totalLaps}
               unit={isAssistiveIndexZero ? '미터(m)' : '바퀴'}
               wrapperClassName={css({ marginTop: '16px' })}

--- a/features/record/components/organisms/distance-page-modal.tsx
+++ b/features/record/components/organisms/distance-page-modal.tsx
@@ -182,7 +182,9 @@ export function DistancePageModal({
                   ? '레인 길이에 따라 자동으로 거리를 계산해드릴게요'
                   : undefined
               }
-              maxLength={isAssistiveIndexOne ? 3 : 5}
+              maxLength={isAssistiveIndexZero ? 5 : 3}
+              step={isAssistiveIndexZero ? undefined : 0.5}
+              preventDecimal={isAssistiveIndexZero}
               value={isAssistiveIndexZero ? totalMeter : totalLaps}
               unit={isAssistiveIndexZero ? '미터(m)' : '바퀴'}
               wrapperClassName={css({ marginTop: '16px' })}

--- a/features/record/components/organisms/sub-info-text-fields.tsx
+++ b/features/record/components/organisms/sub-info-text-fields.tsx
@@ -19,6 +19,7 @@ export function SubInfoTextFields() {
             name: 'heartRate',
           }) as number
         }
+        preventDecimal
         maxLength={3}
         inputType="number"
         label="심박수"
@@ -34,6 +35,7 @@ export function SubInfoTextFields() {
               name: 'paceMinutes',
             }) as number
           }
+          preventDecimal
           maxLength={2}
           inputType="number"
           label="페이스"
@@ -48,6 +50,7 @@ export function SubInfoTextFields() {
               name: 'paceSeconds',
             }) as number
           }
+          preventDecimal
           maxLength={2}
           inputType="number"
           unit="/100m"
@@ -62,6 +65,7 @@ export function SubInfoTextFields() {
             name: 'kcal' as string,
           }) as number
         }
+        preventDecimal
         maxLength={4}
         inputType="number"
         label="칼로리"

--- a/utils/index.ts
+++ b/utils/index.ts
@@ -1,5 +1,6 @@
 export * from './date';
 export * from './image';
+export * from './input';
 export * from './number';
 export * from './time';
 export * from './visualization';

--- a/utils/input/index.ts
+++ b/utils/input/index.ts
@@ -1,0 +1,1 @@
+export * from './prevent-minus';

--- a/utils/input/index.ts
+++ b/utils/input/index.ts
@@ -1,1 +1,1 @@
-export * from './prevent-minus';
+export * from './prevent-characters';

--- a/utils/input/prevent-characters.ts
+++ b/utils/input/prevent-characters.ts
@@ -1,0 +1,10 @@
+import { KeyboardEvent } from 'react';
+
+export const preventCharacters = (
+  event: KeyboardEvent<HTMLInputElement>,
+  blockedChars: string[],
+) => {
+  if (blockedChars.includes(event.key)) {
+    event.preventDefault();
+  }
+};

--- a/utils/input/prevent-minus.ts
+++ b/utils/input/prevent-minus.ts
@@ -1,7 +1,0 @@
-import { KeyboardEvent } from 'react';
-
-export const preventMinus = (event: KeyboardEvent<HTMLInputElement>) => {
-  if (event.key === '-') {
-    event.preventDefault();
-  }
-};

--- a/utils/input/prevent-minus.ts
+++ b/utils/input/prevent-minus.ts
@@ -1,0 +1,7 @@
+import { KeyboardEvent } from 'react';
+
+export const preventMinus = (event: KeyboardEvent<HTMLInputElement>) => {
+  if (event.key === '-') {
+    event.preventDefault();
+  }
+};


### PR DESCRIPTION
## 🤔 어떤 문제가 발생했나요?

- 심박수 & 페이스 & 칼로리 input / 수영 거리 기록 페이지 모달 input 에 마이너스 입력이 허용되고 있었습니다.

- 수영 거리 기록 페이지 모달 input 에 maxLength가 적용되지 않았습니다.

## 🎉 어떻게 해결했나요?

- 마이너스 기호 입력을 keyDown 이벤트로 방지하였습니다.

- maxLength 속성을 외부에서 넘겨주었습니다(바퀴 수: 세자리까지, 미터 수: 다섯자리 까지)

### 📷 이미지 첨부 (Option)

- NA

### ⚠️ 유의할 점! (Option)

- handleInputChange 함수 내부에서 막기를 시도했는데, 마이너스 기호가 정규식으로 제한이 안되는 것 같아 keyDown 이벤트를 활용하였습니다!
