### PR TITLE
chore: 바퀴 수의 소수점 입력을 0.5단위로 제한합니다.

### DIFF
--- a/components/molecules/page-modal/page-modal.css
+++ b/components/molecules/page-modal/page-modal.css
@@ -1,10 +1,10 @@
 .page-jump-forward-enter {
-  transform: translateX(100%);
+  left: 100%;
 }
 
 .page-jump-forward-enter-active {
-  transform: translateX(0);
-  transition: transform 300ms ease-in-out;
+  left: 0;
+  transition: left 300ms ease-in-out;
 }
 
 .page-jump-backward-exit {

--- a/components/molecules/page-modal/page-modal.css
+++ b/components/molecules/page-modal/page-modal.css
@@ -1,10 +1,10 @@
 .page-jump-forward-enter {
-  left: 100%;
+  transform: translateX(100%);
 }
 
 .page-jump-forward-enter-active {
-  left: 0;
-  transition: left 300ms ease-in-out;
+  transform: translateX(0);
+  transition: transform 300ms ease-in-out;
 }
 
 .page-jump-backward-exit {

--- a/components/molecules/text-field/form-text-field.tsx
+++ b/components/molecules/text-field/form-text-field.tsx
@@ -24,6 +24,7 @@ import { useFormTextField } from './use-form-text-field';
  * @param placeholder placeholder 값
  * @param unit 입력값 단위
  * @param maxLength input의 최대길이
+ * @param step 단위 제한
  * @param registerName input 요소를 구독할 때 사용할 name
  * @param className input 태그 추가 스타일
  * @param wrapperClassName text-field-wrapper 컴포넌트 추가 스타일 부여
@@ -60,6 +61,7 @@ export const FormTextField = forwardRef<HTMLInputElement, FormTextFieldProps>(
     const shouldEmphasize = isWritten || focused;
 
     const handleInputChange = (event: ChangeEvent<HTMLInputElement>) => {
+      //최대 길이 제한
       if (maxLength && event.target.value.length >= maxLength) {
         event.target.value = event.target.value.slice(0, maxLength);
         void onChange(event);

--- a/components/molecules/text-field/form-text-field.tsx
+++ b/components/molecules/text-field/form-text-field.tsx
@@ -1,9 +1,9 @@
 'use client';
 
-import React, { ChangeEvent, forwardRef } from 'react';
+import React, { ChangeEvent, forwardRef, KeyboardEvent } from 'react';
 
 import { css, cx } from '@/styled-system/css';
-import { preventMinus } from '@/utils';
+import { preventCharacters } from '@/utils';
 
 import {
   absoluteStyles,
@@ -24,7 +24,6 @@ import { useFormTextField } from './use-form-text-field';
  * @param placeholder placeholder 값
  * @param unit 입력값 단위
  * @param maxLength input의 최대길이
- * @param step 단위 제한
  * @param registerName input 요소를 구독할 때 사용할 name
  * @param className input 태그 추가 스타일
  * @param wrapperClassName text-field-wrapper 컴포넌트 추가 스타일 부여
@@ -44,6 +43,7 @@ export const FormTextField = forwardRef<HTMLInputElement, FormTextFieldProps>(
       subText,
       placeholder,
       unit,
+      preventDecimal,
       className,
       maxLength,
       wrapperClassName,
@@ -61,11 +61,14 @@ export const FormTextField = forwardRef<HTMLInputElement, FormTextFieldProps>(
     const shouldEmphasize = isWritten || focused;
 
     const handleInputChange = (event: ChangeEvent<HTMLInputElement>) => {
-      //최대 길이 제한
       if (maxLength && event.target.value.length >= maxLength) {
         event.target.value = event.target.value.slice(0, maxLength);
         void onChange(event);
       } else void onChange(event);
+    };
+
+    const handleKeyDown = (event: KeyboardEvent<HTMLInputElement>) => {
+      preventCharacters(event, ['-', preventDecimal ? '.' : '']);
     };
 
     return (
@@ -84,7 +87,7 @@ export const FormTextField = forwardRef<HTMLInputElement, FormTextFieldProps>(
             maxLength={maxLength}
             onFocus={() => handlers.onChangeFocus(true)}
             onBlur={() => handlers.onChangeFocus(false)}
-            onKeyDown={inputType === 'number' ? preventMinus : undefined}
+            onKeyDown={inputType === 'number' ? handleKeyDown : undefined}
             onChange={handleInputChange}
             className={cx(
               css(

--- a/components/molecules/text-field/text-field.tsx
+++ b/components/molecules/text-field/text-field.tsx
@@ -1,9 +1,9 @@
 'use client';
 
-import { ChangeEvent } from 'react';
+import { ChangeEvent, KeyboardEvent } from 'react';
 
 import { css, cx } from '@/styled-system/css';
-import { preventMinus } from '@/utils';
+import { preventCharacters } from '@/utils';
 
 import {
   absoluteStyles,
@@ -41,6 +41,7 @@ export function TextField({
   placeholder,
   unit,
   step,
+  preventDecimal,
   maxLength,
   className,
   wrapperClassName,
@@ -74,6 +75,10 @@ export function TextField({
     void onChange?.(newValue);
   };
 
+  const handleKeyDown = (event: KeyboardEvent<HTMLInputElement>) => {
+    preventCharacters(event, ['-', preventDecimal ? '.' : '']);
+  };
+
   return (
     <TextFieldWrapper
       isRequired={isRequired}
@@ -93,7 +98,7 @@ export function TextField({
             onChange={handleInputChange}
             onFocus={() => handlers.onChangeFocus(true)}
             onBlur={() => handlers.onChangeFocus(false)}
-            onKeyDown={inputType === 'number' ? preventMinus : undefined}
+            onKeyDown={inputType === 'number' ? handleKeyDown : undefined}
             className={cx(
               css(
                 shouldEmphasize

--- a/components/molecules/text-field/text-field.tsx
+++ b/components/molecules/text-field/text-field.tsx
@@ -24,6 +24,7 @@ import { useTextField } from './use-text-field';
  * @param subText 추가 설명 텍스트
  * @param placeholder placeholder 값
  * @param unit 입력값 단위
+ * @param step 소수점 단위 제한
  * @param maxLength input의 최대길이
  * @param className input태그 추가 스타일
  * @param wrapperClassName text-field-wrapper 컴포넌트 추가 스타일 부여
@@ -39,6 +40,7 @@ export function TextField({
   subText,
   placeholder,
   unit,
+  step,
   maxLength,
   className,
   wrapperClassName,
@@ -52,11 +54,24 @@ export function TextField({
 
   const handleInputChange = (event: ChangeEvent<HTMLInputElement>) => {
     let newValue = event.target.value;
+    let numValue = parseFloat(event.target.value);
 
-    if (maxLength && newValue.length >= maxLength) {
-      newValue = newValue.slice(0, maxLength);
-      void onChange?.(newValue);
-    } else void onChange?.(newValue);
+    //소수점 단위가 제한되어 있을 때
+    if (step && numValue % step !== 0) {
+      numValue = Math.round(numValue * 2) / 2;
+      newValue = numValue.toString();
+    }
+
+    const lengthWithoutDecimal = newValue.replace('.', '').length;
+
+    //소수점도 고려한 maxLength 적용
+    if (maxLength && lengthWithoutDecimal >= maxLength) {
+      newValue = newValue.slice(
+        0,
+        maxLength + (newValue.includes('.') ? 2 : 0),
+      );
+    }
+    void onChange?.(newValue);
   };
 
   return (

--- a/components/molecules/text-field/type.ts
+++ b/components/molecules/text-field/type.ts
@@ -10,6 +10,7 @@ export interface TextFieldProps {
   placeholder?: string;
   unit?: string;
   maxLength?: number;
+  step?: number;
   className?: string;
   wrapperClassName?: string;
   absoluteClassName?: string;

--- a/components/molecules/text-field/type.ts
+++ b/components/molecules/text-field/type.ts
@@ -11,6 +11,7 @@ export interface TextFieldProps {
   unit?: string;
   maxLength?: number;
   step?: number;
+  preventDecimal?: boolean;
   className?: string;
   wrapperClassName?: string;
   absoluteClassName?: string;

--- a/features/record/components/molecules/distance-field-with-badge.tsx
+++ b/features/record/components/molecules/distance-field-with-badge.tsx
@@ -47,6 +47,8 @@ export function DistanceFieldWithBadge({
       <TextField
         inputType="number"
         maxLength={isAssistiveTabIndexZero ? 5 : 3}
+        step={isAssistiveTabIndexZero ? undefined : 0.5}
+        preventDecimal={isAssistiveTabIndexZero}
         placeholder="0"
         value={value ? String(value) : ''}
         unit={unit}

--- a/features/record/components/organisms/distance-page-modal.tsx
+++ b/features/record/components/organisms/distance-page-modal.tsx
@@ -183,6 +183,7 @@ export function DistancePageModal({
                   : undefined
               }
               maxLength={isAssistiveIndexOne ? 3 : 5}
+              step={isAssistiveIndexOne ? 0.5 : undefined}
               value={isAssistiveIndexZero ? totalMeter : totalLaps}
               unit={isAssistiveIndexZero ? '미터(m)' : '바퀴'}
               wrapperClassName={css({ marginTop: '16px' })}

--- a/features/record/components/organisms/distance-page-modal.tsx
+++ b/features/record/components/organisms/distance-page-modal.tsx
@@ -182,8 +182,9 @@ export function DistancePageModal({
                   ? '레인 길이에 따라 자동으로 거리를 계산해드릴게요'
                   : undefined
               }
-              maxLength={isAssistiveIndexOne ? 3 : 5}
-              step={isAssistiveIndexOne ? 0.5 : undefined}
+              maxLength={isAssistiveIndexZero ? 5 : 3}
+              step={isAssistiveIndexZero ? undefined : 0.5}
+              preventDecimal={isAssistiveIndexZero}
               value={isAssistiveIndexZero ? totalMeter : totalLaps}
               unit={isAssistiveIndexZero ? '미터(m)' : '바퀴'}
               wrapperClassName={css({ marginTop: '16px' })}

--- a/features/record/components/organisms/sub-info-text-fields.tsx
+++ b/features/record/components/organisms/sub-info-text-fields.tsx
@@ -19,6 +19,7 @@ export function SubInfoTextFields() {
             name: 'heartRate',
           }) as number
         }
+        preventDecimal
         maxLength={3}
         inputType="number"
         label="심박수"
@@ -34,6 +35,7 @@ export function SubInfoTextFields() {
               name: 'paceMinutes',
             }) as number
           }
+          preventDecimal
           maxLength={2}
           inputType="number"
           label="페이스"
@@ -48,6 +50,7 @@ export function SubInfoTextFields() {
               name: 'paceSeconds',
             }) as number
           }
+          preventDecimal
           maxLength={2}
           inputType="number"
           unit="/100m"
@@ -62,6 +65,7 @@ export function SubInfoTextFields() {
             name: 'kcal' as string,
           }) as number
         }
+        preventDecimal
         maxLength={4}
         inputType="number"
         label="칼로리"

--- a/utils/input/index.ts
+++ b/utils/input/index.ts
@@ -1,1 +1,1 @@
-export * from './prevent-minus';
+export * from './prevent-characters';

--- a/utils/input/prevent-characters.ts
+++ b/utils/input/prevent-characters.ts
@@ -1,0 +1,10 @@
+import { KeyboardEvent } from 'react';
+
+export const preventCharacters = (
+  event: KeyboardEvent<HTMLInputElement>,
+  blockedChars: string[],
+) => {
+  if (blockedChars.includes(event.key)) {
+    event.preventDefault();
+  }
+};

--- a/utils/input/prevent-minus.ts
+++ b/utils/input/prevent-minus.ts
@@ -1,7 +1,0 @@
-import { KeyboardEvent } from 'react';
-
-export const preventMinus = (event: KeyboardEvent<HTMLInputElement>) => {
-  if (event.key === '-') {
-    event.preventDefault();
-  }
-};


### PR DESCRIPTION
## 🤔 어떤 문제가 발생했나요?

- 바퀴 수 입력 시, 아무 단위로나 마음껏 입력이 가능했습니다.

## 🎉 어떻게 해결했나요?

- 소수점으로 입력될 시, 0.5 단위로 변환되게 함으로써 0.5 단위로의 기록 저장만 허용하였습니다.

- 추가로 미터 입력 시에는 소수점 입력을 아예 제한해주었습니다.

### 📷 이미지 첨부 (Option)

예시

- 바퀴 수에 2.3 입력 시

https://github.com/user-attachments/assets/80a7c796-e1ee-41d5-8f68-7cbb53728a7b

- 바퀴 수에 4.1 입력 시

https://github.com/user-attachments/assets/0424e56e-7fab-4ba4-93d1-ee7d69befdf4

### ⚠️ 유의할 점! (Option)

- NA
