### PR TITLE
fix: 기록 상세 페이지에서 목표 달성에도 그라데이션으로 보이지 않는 현상 수정

### DIFF
--- a/features/record-detail/sections/detail-preview.tsx
+++ b/features/record-detail/sections/detail-preview.tsx
@@ -65,7 +65,7 @@ export const DetailPreviewSection = ({ data }: { data: RecordDetailType }) => {
           {strokes?.length && member?.goal ? (
             <RecordMark
               isAchieved={Boolean(
-                member?.goal && totalMeter && totalMeter > member?.goal,
+                member?.goal && totalMeter && totalMeter >= member?.goal,
               )}
               strokes={strokes}
               totalDistance={totalMeter}


### PR DESCRIPTION
<!-- 작성 예시 -->
<!-- # 어떤 문제가 발생했나요? -->
<!-- - 간략한 문제 설명 -->
<!-- - 문제 관련 링크 등등 -->
<!-- Ex) React v18 version update에 후 테스트에서 에러가 발생합니다.
  라이브러리의 버전이 호환이 되지않아서 문제입니다. -->

<!-- # 어떻게 해결했나요? -->
<!-- - 동작 방식 등 수정힌 코드에 대한 설명 -->
<!-- Ex) 라이브러리의 버전을 업데이트하고, v18을 사용할 수 있도록 dev dependency로 설치해주었습니다. -->

<!-- # 이미지 첨부 (Option) -->
<!-- - 이번 PR의 동작 이해를 돕는 GIF나 이미지 파일 첨부! -->
<!-- - 만약 없다면, NA 혹은 비워둡시다~ -->

<!-- # 유의할 점 (Option) -->
<!-- - 추가적으로 고민중이거나 조언을 구하고 싶은 내용, 어떤 것을 중점으로 리뷰를 해줬으면 좋겠는지 등등 작성 -->
<!-- - 만약 없다면, NA 혹은 비워둡시다~ -->

## 🤔 어떤 문제가 발생했나요?

- 사용자가 설정한 목표를 달성했음에도 일반 기록처럼 보이던 현상이 발생했습니다.

## 🎉 어떻게 해결했나요?

- 조건문을 수정하여 정상적으로 보이도록 수정하였습니다.

### 📷 이미지 첨부 (Option)

-

### ⚠️ 유의할 점! (Option)

-

<!-- PR merge시 닫을 이슈가 있다면, 번호를 작성해주세요 -->
<!-- Ex) close #12 -->
