### PR TITLE
feat: 이전 기록 시간을 다음 기록에 반영하는 로직 & 첫 기록 시 시간 바텀 시트를 자동으로 열어주는 로직을 구현합니다.

### DIFF
--- a/app/record/page.tsx
+++ b/app/record/page.tsx
@@ -16,8 +16,8 @@ const DynamicBackButton = dynamic(
 );
 
 export default function RecordPage() {
-  const prevSwimStartTime = cookies().get('startTime')?.value;
-  const prevSwimEndTime = cookies().get('endTime')?.value;
+  const prevSwimStartTime = cookies().get('swimStartTime')?.value;
+  const prevSwimEndTime = cookies().get('swimEndTime')?.value;
   return (
     <div>
       <HeaderBar className={css({ marginBottom: '24px' })}>

--- a/app/record/page.tsx
+++ b/app/record/page.tsx
@@ -1,4 +1,5 @@
 import dynamic from 'next/dynamic';
+import { cookies } from 'next/headers';
 import { Suspense } from 'react';
 
 import { LeftArrowIcon } from '@/components/atoms';
@@ -15,6 +16,8 @@ const DynamicBackButton = dynamic(
 );
 
 export default function RecordPage() {
+  const prevSwimStartTime = cookies().get('startTime')?.value;
+  const prevSwimEndTime = cookies().get('endTime')?.value;
   return (
     <div>
       <HeaderBar className={css({ marginBottom: '24px' })}>
@@ -26,7 +29,10 @@ export default function RecordPage() {
       {/* Title 컴포넌트 생성 시 대체 */}
       <h1 className={titleStyles.form}>기본정보</h1>
       <Suspense>
-        <Form />
+        <Form
+          prevSwimStartTime={prevSwimStartTime}
+          prevSwimEndTime={prevSwimEndTime}
+        />
       </Suspense>
     </div>
   );

--- a/features/record/components/organisms/form.tsx
+++ b/features/record/components/organisms/form.tsx
@@ -140,7 +140,7 @@ export function Form({ prevSwimStartTime, prevSwimEndTime }: FormProps) {
   });
 
   const { isLoading, modifySubmitData, modifyStrokesData, handlers } =
-    useRecordForm(lane);
+    useRecordForm(lane, isEditMode, prevSwimStartTime);
 
   const handleRecordEditSuccess = () => {
     handlers.onChangeIsLoading(false);

--- a/features/record/components/organisms/form.tsx
+++ b/features/record/components/organisms/form.tsx
@@ -31,6 +31,7 @@ import {
   usePullEditMemory,
 } from '../../apis';
 import { useRecordForm } from '../../hooks';
+import { saveSwimTime } from '../../server-actions';
 import { formSubInfoState } from '../../store/form-sub-info';
 import { formSectionStyles } from '../../styles/form-section';
 import { compareTime } from '../../utils';
@@ -43,10 +44,14 @@ import { PoolSearchPageModal } from './pool-search-page-modal';
 import { SubInfoSection } from './sub-info-section';
 import { TimeBottomSheet } from './time-bottom-sheet';
 
+interface FormProps {
+  prevSwimStartTime?: string;
+  prevSwimEndTime?: string;
+}
+
 //Todo: 코드 개선
-//Todo: 수정모드일 시, 기록 불러올 때 보여줄 로딩 UI 구현
 //Todo: 수정모드일 시, 불러온 기록 데이터에서 차이가 없을 때는 버튼 disabled
-export function Form() {
+export function Form({ prevSwimStartTime, prevSwimEndTime }: FormProps) {
   const searchParams = useSearchParams();
   const date = searchParams.get('date');
   const memoryId = searchParams.get('memoryId');
@@ -62,8 +67,8 @@ export function Form() {
   const methods = useForm<RecordRequestProps>({
     defaultValues: {
       recordAt: date ? formatDateToKorean(date) : getToday(),
-      startTime: '',
-      endTime: '',
+      startTime: prevSwimStartTime ? prevSwimStartTime : '',
+      endTime: prevSwimEndTime ? prevSwimEndTime : '',
       poolName: '',
       laneMeter: '25m',
       lane: 25,
@@ -176,7 +181,6 @@ export function Form() {
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     const { poolName, laneMeter, totalDistance, ...restData } = data;
     const submitData = modifySubmitData(restData);
-
     handlers.onChangeIsLoading(true);
     if (isEditMode) {
       //이미지가 수정 되었을 때
@@ -214,6 +218,7 @@ export function Form() {
     }
     //기록 생성 모드일 때
     else {
+      saveSwimTime(submitData.startTime, submitData.endTime);
       //기록에서 이미지가 포함되었을 때
       if (formSubInfo.imageFiles.length > 0) {
         const getImagePresignedUrlRes = await getImagePresignedUrl([
@@ -340,7 +345,10 @@ export function Form() {
         defaultTotalLap={data?.data.totalLap}
         defaultTotalMeter={data?.data.totalMeter}
       />
-      <TimeBottomSheet />
+      <TimeBottomSheet
+        prevSwimStartTime={prevSwimStartTime}
+        prevSwimEndTime={prevSwimEndTime}
+      />
     </FormProvider>
   );
 }

--- a/features/record/components/organisms/time-bottom-sheet.tsx
+++ b/features/record/components/organisms/time-bottom-sheet.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useAtom } from 'jotai';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useFormContext } from 'react-hook-form';
 import Picker from 'react-mobile-picker';
 
@@ -13,9 +13,21 @@ import { css } from '@/styled-system/css';
 import { timeOptions } from '../../constants';
 import { timeBottomSheetState } from '../../store';
 import { AmpmType, HourType, MinuteType } from '../../types';
-import { addMinutes, convertTo24HourFormat } from '../../utils';
+import {
+  addMinutes,
+  convertTo24HourFormat,
+  convertToPickerValue,
+} from '../../utils';
 
-export function TimeBottomSheet() {
+interface TimeBottomSheetProps {
+  prevSwimStartTime?: string;
+  prevSwimEndTime?: string;
+}
+
+export function TimeBottomSheet({
+  prevSwimStartTime,
+  prevSwimEndTime,
+}: TimeBottomSheetProps) {
   const { getValues, setValue } = useFormContext();
   const [timeBottmSheetState, setTimeBottmSheetState] =
     useAtom(timeBottomSheetState);
@@ -25,10 +37,18 @@ export function TimeBottomSheet() {
     hour: HourType;
     minute: MinuteType;
   }>({
-    ampm: '오후',
+    ampm: '오전',
     hour: '02',
     minute: '05',
   });
+
+  useEffect(() => {
+    if (timeBottmSheetState.variant === 'start')
+      setPickerValue(convertToPickerValue(prevSwimStartTime));
+    if (timeBottmSheetState.variant === 'end')
+      setPickerValue(convertToPickerValue(prevSwimEndTime));
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [timeBottmSheetState.variant]);
 
   usePreventBodyScroll({ isOpen: timeBottmSheetState.isOpen });
 

--- a/features/record/components/organisms/time-bottom-sheet.tsx
+++ b/features/record/components/organisms/time-bottom-sheet.tsx
@@ -10,7 +10,7 @@ import { BottomSheet } from '@/components/molecules';
 import { usePreventBodyScroll } from '@/hooks';
 import { css } from '@/styled-system/css';
 
-import { timeOptions } from '../../constants';
+import { defaultPickerValue, timeOptions } from '../../constants';
 import { timeBottomSheetState } from '../../store';
 import { AmpmType, HourType, MinuteType } from '../../types';
 import {
@@ -36,11 +36,7 @@ export function TimeBottomSheet({
     ampm: AmpmType;
     hour: HourType;
     minute: MinuteType;
-  }>({
-    ampm: '오전',
-    hour: '02',
-    minute: '05',
-  });
+  }>(defaultPickerValue);
 
   useEffect(() => {
     if (timeBottmSheetState.variant === 'start')

--- a/features/record/constants/index.ts
+++ b/features/record/constants/index.ts
@@ -1,3 +1,3 @@
 export * from './lane';
 export * from './stroke-options';
-export * from './time-options';
+export * from './time';

--- a/features/record/constants/time.ts
+++ b/features/record/constants/time.ts
@@ -1,3 +1,5 @@
+import { AmpmType, HourType, MinuteType } from '../types';
+
 export const timeOptions = {
   ampm: ['오전', '오후'],
   hour: [
@@ -28,4 +30,10 @@ export const timeOptions = {
     '50',
     '55',
   ],
+};
+
+export const defaultPickerValue = {
+  ampm: '오후' as AmpmType,
+  hour: '02' as HourType,
+  minute: '05' as MinuteType,
 };

--- a/features/record/hooks/use-record-form.tsx
+++ b/features/record/hooks/use-record-form.tsx
@@ -14,7 +14,11 @@ import {
 } from '../store';
 import { StrokeProps } from '../types';
 
-export function useRecordForm(lane: number) {
+export function useRecordForm(
+  lane: number,
+  isEditMode: boolean,
+  prevSwimStartTime?: string,
+) {
   const [isLoading, setIsLoading] = useState(false);
   const setIsPoolSearchPageModalOpen = useSetAtom(isPoolSearchPageModalOpen);
   const setIsDistancePageModalOpen = useSetAtom(isDistancePageModalOpen);
@@ -114,6 +118,11 @@ export function useRecordForm(lane: number) {
           .join(' · ');
     }
   };
+
+  useEffect(() => {
+    if (!isEditMode && !prevSwimStartTime) openStartTimeBottomSheet();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   useEffect(() => {
     const handleHashChange = () => {

--- a/features/record/server-actions/index.ts
+++ b/features/record/server-actions/index.ts
@@ -1,1 +1,2 @@
 export * from './revalidate-record-detail';
+export * from './save-swim-time';

--- a/features/record/server-actions/save-swim-time.ts
+++ b/features/record/server-actions/save-swim-time.ts
@@ -1,0 +1,20 @@
+'use server';
+
+import { cookies } from 'next/headers';
+
+export const saveSwimTime = (startTime: string, endTime: string) => {
+  const prevStartTime = cookies().get('startTime')?.value;
+  const prevEndTime = cookies().get('endTime')?.value;
+  if (!prevStartTime || (prevStartTime && prevStartTime !== startTime))
+    cookies().set('startTime', startTime, {
+      maxAge: Infinity,
+      httpOnly: true,
+      secure: true,
+    });
+  if (!prevEndTime || (prevEndTime && prevEndTime !== endTime))
+    cookies().set('endTime', endTime, {
+      maxAge: Infinity,
+      httpOnly: true,
+      secure: true,
+    });
+};

--- a/features/record/server-actions/save-swim-time.ts
+++ b/features/record/server-actions/save-swim-time.ts
@@ -3,16 +3,19 @@
 import { cookies } from 'next/headers';
 
 export const saveSwimTime = (startTime: string, endTime: string) => {
-  const prevStartTime = cookies().get('startTime')?.value;
-  const prevEndTime = cookies().get('endTime')?.value;
-  if (!prevStartTime || (prevStartTime && prevStartTime !== startTime))
-    cookies().set('startTime', startTime, {
+  const prevSwimStartTime = cookies().get('swimStartTime')?.value;
+  const prevSwimEndTime = cookies().get('swimEndTime')?.value;
+  if (
+    !prevSwimStartTime ||
+    (prevSwimStartTime && prevSwimStartTime !== startTime)
+  )
+    cookies().set('swimStartTime', startTime, {
       maxAge: Infinity,
       httpOnly: true,
       secure: true,
     });
-  if (!prevEndTime || (prevEndTime && prevEndTime !== endTime))
-    cookies().set('endTime', endTime, {
+  if (!prevSwimEndTime || (prevSwimEndTime && prevSwimEndTime !== endTime))
+    cookies().set('swimEndTime', endTime, {
       maxAge: Infinity,
       httpOnly: true,
       secure: true,

--- a/features/record/utils/time.ts
+++ b/features/record/utils/time.ts
@@ -18,6 +18,31 @@ export const convertTo24HourFormat = (pickerValue: {
   return `${hour24.toString().padStart(2, '0')}:${pickerValue.minute}`;
 };
 
+export const convertToPickerValue = (time?: string) => {
+  if (!time)
+    return {
+      ampm: '오후' as AmpmType,
+      hour: '02' as HourType,
+      minute: '05' as MinuteType,
+    };
+  let hour = time.split(':').map(Number)[0];
+  const minute = time.split(':').map(Number)[1];
+
+  const ampm = hour >= 12 ? '오후' : '오전';
+
+  if (hour > 12) hour -= 12;
+  if (hour === 0) hour = 12;
+
+  const hourStr = hour.toString().padStart(2, '0');
+  const minuteStr = minute.toString().padStart(2, '0');
+
+  return {
+    ampm: ampm as AmpmType,
+    hour: hourStr as HourType,
+    minute: minuteStr as MinuteType,
+  };
+};
+
 export const addMinutes = (
   pickerValue: {
     ampm: AmpmType;

--- a/features/record/utils/time.ts
+++ b/features/record/utils/time.ts
@@ -1,3 +1,4 @@
+import { defaultPickerValue } from '../constants';
 import { AmpmType, HourType, MinuteType } from '../types';
 
 export const convertTo24HourFormat = (pickerValue: {
@@ -19,12 +20,7 @@ export const convertTo24HourFormat = (pickerValue: {
 };
 
 export const convertToPickerValue = (time?: string) => {
-  if (!time)
-    return {
-      ampm: '오후' as AmpmType,
-      hour: '02' as HourType,
-      minute: '05' as MinuteType,
-    };
+  if (!time) return defaultPickerValue;
   let hour = time.split(':').map(Number)[0];
   const minute = time.split(':').map(Number)[1];
 


### PR DESCRIPTION
## 🤔 어떤 문제가 발생했나요?

-

## 🎉 어떻게 해결했나요?

- 이전 기록 시간을 다음 기록에 반영하는 로직 & 첫 기록 시 시간 바텀 시트를 자동으로 열어주는 로직을 구현하였습니다.

- 이전 기록 시간을 저장 후 나중에 불러오기 위해 next/cookie를 활용하였습니다.

### 📷 이미지 첨부 (Option)

- 첫 기록 시

https://github.com/user-attachments/assets/825f79e6-63c9-40bb-a804-312bb33f6843

- 두번째 이후 기록 시

https://github.com/user-attachments/assets/19c662bc-cbdb-4bf2-9c0c-d8d317881dbb

### ⚠️ 유의할 점! (Option)

- NA
