### PR TITLE
fix: 수영장 검색 page-modal에서, 스크롤되는 영역을 수정합니다.

### DIFF
--- a/components/molecules/page-modal/page-modal.tsx
+++ b/components/molecules/page-modal/page-modal.tsx
@@ -49,4 +49,8 @@ const layoutStyles = css({
   backgroundColor: 'white',
   zIndex: 1000,
   overflow: 'auto',
+
+  '&::-webkit-scrollbar': {
+    display: 'none',
+  },
 });

--- a/features/record/components/organisms/pool-search-page-modal.tsx
+++ b/features/record/components/organisms/pool-search-page-modal.tsx
@@ -63,7 +63,7 @@ export function PoolSearchPageModal({ title }: PoolSearchPageModalProps) {
             <BackButton onClickBack={handleBackArrowClick} />
           </HeaderBar.LeftContent>
         </HeaderBar>
-        <div className={layoutStyles}>
+        <div className={layoutStyles.fixed}>
           <h2 className={textStyles.title}>{title}</h2>
           <SearchBar
             value={poolSearchText}
@@ -77,7 +77,9 @@ export function PoolSearchPageModal({ title }: PoolSearchPageModalProps) {
               <br /> 즐겨찾기할 수 있어요
             </p>
           )}
-          {/* Todo: 스켈레톤 컴포넌트 */}
+        </div>
+        <div style={{ height: '106px' }} />
+        <div className={layoutStyles.result}>
           {!poolSearchText && !isDataEmpty && (
             <Suspense fallback={<PoolSearchSkeleton />}>
               <div className={css({ padding: '16px 0' })}>
@@ -105,9 +107,18 @@ export function PoolSearchPageModal({ title }: PoolSearchPageModalProps) {
   );
 }
 
-const layoutStyles = css({
-  padding: '0 20px',
-});
+const layoutStyles = {
+  fixed: css({
+    padding: '0 20px',
+    position: 'fixed',
+    w: 'full',
+    maxWidth: 'maxWidth',
+    backgroundColor: 'background.white',
+  }),
+  result: css({
+    padding: '0 20px',
+  }),
+};
 
 const textStyles = {
   title: css({


### PR DESCRIPTION
## 🤔 어떤 문제가 발생했나요?

- 수영장 검색 page-modal에서 검색 결과 리스트만 스크롤 되도록 구현해야 했습니다.
 
## 🎉 어떻게 해결했나요?

- 검색 결과만 스크롤 되도록 서치바 까지 fixed로 설정 후, placeholder dom을 설정해 주었습니다. 

### 📷 이미지 첨부 (Option)

https://github.com/user-attachments/assets/b5f67b2c-248f-4a61-b5da-d640291c2483

### ⚠️ 유의할 점! (Option)

- 특정 구역까지 fixed로 설정해놓는게 최선일까는 약간 의문이 드네요..!! 다른 방식이 있다면 커멘트 남겨주세요 :)
