### PR TITLE
fix: 수영 거리가 없는 상태에서 레인 수정시, 0m 혹은 NaN이 뜨는 버그 수정

### DIFF
--- a/features/record/components/organisms/form.tsx
+++ b/features/record/components/organisms/form.tsx
@@ -87,7 +87,7 @@ export function Form({ prevSwimStartTime, prevSwimEndTime }: FormProps) {
         lane: prevData.lane,
         laneMeter: prevData.lane + 'm',
         poolId: prevData?.pool?.id ? prevData.pool.id : undefined,
-        poolName: prevData?.pool?.name ? prevData.pool.name : undefined,
+        poolName: prevData?.pool?.name ? prevData.pool.name : '',
         diary: prevData.diary ? prevData.diary : undefined,
         item: prevData.memoryDetail?.item
           ? prevData.memoryDetail.item
@@ -107,7 +107,7 @@ export function Form({ prevSwimStartTime, prevSwimEndTime }: FormProps) {
         strokes: prevData.strokes ? prevData.strokes : undefined,
         totalDistance: prevData.totalMeter
           ? prevData.totalMeter.toLocaleString() + 'm'
-          : undefined,
+          : '',
       });
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/features/record/components/organisms/lane-length-bottom-sheet.tsx
+++ b/features/record/components/organisms/lane-length-bottom-sheet.tsx
@@ -32,9 +32,14 @@ export function LaneLengthBottomSheet({ title }: LaneLengthBottomSheetProps) {
   }) as string;
 
   const handleSelectLaneLength = (value: string) => {
-    if (formSubInfo.isDistanceLapModified && value === laneOptions[0].label)
+    if (
+      Boolean(totalDistance) &&
+      formSubInfo.isDistanceLapModified &&
+      value === laneOptions[0].label
+    )
       setValue('totalDistance', Number(totalDistance?.slice(0, -1)) / 2 + 'm');
     else if (
+      Boolean(totalDistance) &&
       formSubInfo.isDistanceLapModified &&
       value === laneOptions[1].label
     )


### PR DESCRIPTION
## 🤔 어떤 문제가 발생했나요?

- 수영 거리가 없는 상태에서 레인 수정시, 수영 거리가 바뀌는 버그가 있습니다.

## 🎉 어떻게 해결했나요?

- totalDistance가 정의되어 있을 시에만, 레인 수정이 반영되도록 수정하였습니다.

### 📷 이미지 첨부 (Option)

- before

https://github.com/user-attachments/assets/1f0502e4-4845-4974-b379-776d18d1b434

- after

https://github.com/user-attachments/assets/80707d35-a84e-41e7-913c-dbf15ea3ac78

### ⚠️ 유의할 점! (Option)

- NA
