### PR TITLE
chore: 이전 수영 기록 방법에 따른 디폴트 tab index 분기처리

### DIFF
--- a/features/record/hooks/use-distance-page-modal.tsx
+++ b/features/record/hooks/use-distance-page-modal.tsx
@@ -19,11 +19,22 @@ export function useDistancePageModal<T>(
   defaultTotalMeter?: number,
   defaultTotalLap?: number,
 ) {
+  const isRecordedByTotalMeter =
+    defaultStrokes?.length === 1 && defaultStrokes[0].name === '총거리';
+  const isRecordedByTotalLaps =
+    defaultStrokes?.length === 1 && defaultStrokes[0].name === '총바퀴';
+  const isRecordedByStrokesMeter = defaultStrokes?.every((stroke) =>
+    Boolean(stroke.meter),
+  );
   const [formSubInfo, setFormSubInfo] = useAtom(formSubInfoState);
   const pageModalRef = useRef<T>(null);
   const setPageModalState = useSetAtom(isDistancePageModalOpen);
-  const [secondaryTabIndex, setSecondaryTabIndex] = useState<tabIndex>(0);
-  const [assistiveTabIndex, setAssistiveTabIndex] = useState<tabIndex>(0);
+  const [secondaryTabIndex, setSecondaryTabIndex] = useState<tabIndex>(
+    isRecordedByTotalMeter || isRecordedByTotalLaps ? 0 : 1,
+  );
+  const [assistiveTabIndex, setAssistiveTabIndex] = useState<tabIndex>(
+    isRecordedByTotalMeter || isRecordedByStrokesMeter ? 0 : 1,
+  );
   const [totalMeter, setTotalMeter] = useState<string>('');
   const [totalLaps, setTotalLaps] = useState<string>('');
   const [totalStrokeDistance, setTotalStrokeDistance] = useState<number>(0);


### PR DESCRIPTION
## 🤔 어떤 문제가 발생했나요?

## 🎉 어떻게 해결했나요?

- 이전 수영 기록 방법에 따라 수영 거리 기록 page-modal의 디폴트 tab index를 분기처리 해주었습니다.

### 📷 이미지 첨부 (Option)

- 총 미터로 입력 시

https://github.com/user-attachments/assets/2fba56aa-fb95-404d-afc9-c7f3c25202ce

- 총 바퀴로 입력 시

https://github.com/user-attachments/assets/0ba8c6ce-9c5a-4fc6-a070-b98619dc60e8

- 영법별 미터로 입력 시

https://github.com/user-attachments/assets/9aea2939-ef55-4be3-9a27-6487ad3c1465

- 영법별 바퀴로 입력 시

https://github.com/user-attachments/assets/7dcfe5ed-28f7-4086-a81d-8447ee3c58f6

### ⚠️유의할 점! (Option)

- NA
