### PR TITLE
chore: 기록 수정 플로우 변경

### DIFF
--- a/app/record/success/page.tsx
+++ b/app/record/success/page.tsx
@@ -12,7 +12,6 @@ interface RecordSuccessPageProps {
 export default function RecordSuccessPage({
   searchParams,
 }: RecordSuccessPageProps) {
-  const isEditMode = Boolean(searchParams.editMode);
   return (
     <div className={layoutStyles.full}>
       <div className={layoutStyles.content}>
@@ -23,20 +22,12 @@ export default function RecordSuccessPage({
           priority
           alt="success record"
         />
-        <h3 className={textStyles.title}>
-          {isEditMode ? '수정' : '기록'} 완료!
-        </h3>
-        {isEditMode ? (
-          <p className={textStyles.paragraph}>
-            기록 수정이 성공적으로 완료되었어요.
-          </p>
-        ) : (
-          <p className={textStyles.paragraph}>
-            {searchParams.month}월{' '}
-            <span className={textStyles.sub}>{searchParams.rank}번째</span>{' '}
-            기록이에요.
-          </p>
-        )}
+        <h3 className={textStyles.title}>기록 완료!</h3>
+        <p className={textStyles.paragraph}>
+          {searchParams.month}월{' '}
+          <span className={textStyles.sub}>{searchParams.rank}번째</span>{' '}
+          기록이에요.
+        </p>
       </div>
       <Link
         href={`/record-detail/${searchParams.memoryId}`}

--- a/features/record/components/organisms/form.tsx
+++ b/features/record/components/organisms/form.tsx
@@ -144,9 +144,8 @@ export function Form({ prevSwimStartTime, prevSwimEndTime }: FormProps) {
 
   const handleRecordEditSuccess = () => {
     handlers.onChangeIsLoading(false);
-    router.replace(
-      `/record/success?editMode=true&memoryId=${Number(memoryId)}`,
-    );
+    router.replace(`/record-detail/${Number(memoryId)}`);
+    toast('기록 수정이 완료되었어요.', { type: 'success' });
     setFormSubInfo({
       imageFiles: [],
       isDistanceLapModified: false,


### PR DESCRIPTION
## 🤔 어떤 문제가 발생했나요?


## 🎉 어떻게 해결했나요?

- 기록 수정 시에는 새로운 성공 페이지로 이동하는 것이 아닌, toast를 띄운 후 -> 기록 상세 페이지로 이동되는 플로우로 수정하였습니다.

### 📷 이미지 첨부 (Option)

<img width="500" alt="image" src="https://github.com/user-attachments/assets/491b4c0b-7717-4027-bc24-1032c0deb410">

https://github.com/user-attachments/assets/e25c5bd2-c7ba-4f56-9bff-e2b91cdeb020

### ⚠️ 유의할 점! (Option)

- NA
