### PR TITLE
fix: 수정 모드에서 이전 장비 기록이 UI에 반영 안되는 현상 수정

### DIFF
--- a/features/record/components/organisms/equipment-section.tsx
+++ b/features/record/components/organisms/equipment-section.tsx
@@ -47,10 +47,11 @@ export function EquipmentSection({
     if (defaultEquipment) {
       defaultEquipment.split(',').forEach((equipment) => {
         const swimTool = equipment as SwimToolName;
-        setEquipmentSelectState((prev) => [
-          ...prev,
-          (prev[equipmentList.indexOf(swimTool)] = true),
-        ]);
+        setEquipmentSelectState((prev) =>
+          prev.map((item, i) =>
+            i === equipmentList.indexOf(swimTool) ? true : item,
+          ),
+        );
       });
     }
 


### PR DESCRIPTION
## 🤔 어떤 문제가 발생했나요?

- 이전 장비 기록을 불러올 때, UI에 반영이 안되는 버그가 있었습니다.

## 🎉 어떻게 해결했나요?

- 불러온 정보를 반영하는 코드를 수정하였습니다.

### 📷 이미지 첨부 (Option)

https://github.com/user-attachments/assets/ca66fde5-4a72-4589-a2ad-bd2c8f8733b7

### ⚠️ 유의할 점! (Option)

- NA
