### PR TITLE
chore: 미래 날짜를 직접 url로 치고 기록 시도 시, home으로 replace 처리

### DIFF
--- a/features/record/components/organisms/form.tsx
+++ b/features/record/components/organisms/form.tsx
@@ -35,7 +35,7 @@ import { useRecordForm } from '../../hooks';
 import { saveSwimTime } from '../../server-actions';
 import { formSubInfoState } from '../../store/form-sub-info';
 import { formSectionStyles } from '../../styles/form-section';
-import { compareTime } from '../../utils';
+import { compareTime, isFuture } from '../../utils';
 import { DiarySection } from './diary-section';
 import { DistancePageModal } from './distance-page-modal';
 import { EquipmentSection } from './equipment-section';
@@ -78,6 +78,15 @@ export function Form({ prevSwimStartTime, prevSwimEndTime }: FormProps) {
       imageIdList: [],
     },
   });
+
+  useEffect(() => {
+    if (date && isFuture(date)) {
+      router.replace('/');
+      toast('미래 날짜에는 기록할 수 없어요.', { type: 'warning' });
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [date]);
+
   useEffect(() => {
     if (data) {
       const prevData = data.data;

--- a/features/record/utils/index.ts
+++ b/features/record/utils/index.ts
@@ -1,3 +1,4 @@
 export * from './highlight-text';
+export * from './is-future';
 export * from './remove-special-symbols';
 export * from './time';

--- a/features/record/utils/is-future.ts
+++ b/features/record/utils/is-future.ts
@@ -1,0 +1,7 @@
+export const isFuture = (dateString: string) => {
+  const givenDate = new Date(dateString);
+
+  const currentDate = new Date();
+
+  return givenDate > currentDate;
+};


### PR DESCRIPTION
## 🤔 어떤 문제가 발생했나요?

- 유저가 기록 시도시, 미래 날짜를 직접 url로 입력하면 기록이 허용되는 현상이 있었습니다.

## 🎉 어떻게 해결했나요?

- 미래 날짜를 url로 직접 입력 시, home으로 replace 해주었습니다.

### 📷 이미지 첨부 (Option)

https://github.com/user-attachments/assets/67479fb6-ae3f-4475-9af5-fdf533a145a4

### ⚠️ 유의할 점! (Option)

- NA
