### PR TITLE
fix: 애플 로그인 연타를 방지합니다.

### DIFF
--- a/features/login/components/organisms/login-screen.tsx
+++ b/features/login/components/organisms/login-screen.tsx
@@ -2,6 +2,7 @@
 
 import { motion } from 'framer-motion';
 import Image from 'next/image';
+import { useState } from 'react';
 
 import {
   AppleLogoIcon,
@@ -17,6 +18,8 @@ type LoginScreen = {
   isAnimate?: boolean;
 };
 export const LoginScreen = ({ isAnimate = true }: LoginScreen) => {
+  const [isAppleLoginDisabled, setIsAppleLoginDisabled] = useState(false);
+
   const kakaoLogin = () => {
     window.location.href = `https://kauth.kakao.com/oauth/authorize?client_id=${process.env.NEXT_PUBLIC_KAKAO_CLIENT_ID}&redirect_uri=${process.env.NEXT_PUBLIC_KAKAO_REDIRECT_URI}&response_type=code&prompt=select_account`;
   };
@@ -26,6 +29,7 @@ export const LoginScreen = ({ isAnimate = true }: LoginScreen) => {
   // };
 
   const appleLogin = () => {
+    setIsAppleLoginDisabled(true);
     window.location.href = `https://appleid.apple.com/auth/authorize?client_id=${process.env.NEXT_PUBLIC_APPLE_CLIENT_ID}&redirect_uri=${process.env.NEXT_PUBLIC_APPLE_REDIRECT_URI}&response_type=code id_token&scope=name email&response_mode=form_post`;
   };
 
@@ -93,9 +97,8 @@ export const LoginScreen = ({ isAnimate = true }: LoginScreen) => {
             </button> */}
             <button
               className={buttons({ type: 'apple' })}
-              onClick={() => {
-                void appleLogin();
-              }}
+              onClick={appleLogin}
+              disabled={isAppleLoginDisabled}
             >
               <div className={buttonContent}>
                 <AppleLogoIcon />


### PR DESCRIPTION
<!-- 작성 예시 -->
<!-- # 어떤 문제가 발생했나요? -->
<!-- - 간략한 문제 설명 -->
<!-- - 문제 관련 링크 등등 -->
<!-- Ex) React v18 version update에 후 테스트에서 에러가 발생합니다.
  라이브러리의 버전이 호환이 되지않아서 문제입니다. -->

<!-- # 어떻게 해결했나요? -->
<!-- - 동작 방식 등 수정힌 코드에 대한 설명 -->
<!-- Ex) 라이브러리의 버전을 업데이트하고, v18을 사용할 수 있도록 dev dependency로 설치해주었습니다. -->

<!-- # 이미지 첨부 (Option) -->
<!-- - 이번 PR의 동작 이해를 돕는 GIF나 이미지 파일 첨부! -->
<!-- - 만약 없다면, NA 혹은 비워둡시다~ -->

<!-- # 유의할 점 (Option) -->
<!-- - 추가적으로 고민중이거나 조언을 구하고 싶은 내용, 어떤 것을 중점으로 리뷰를 해줬으면 좋겠는지 등등 작성 -->
<!-- - 만약 없다면, NA 혹은 비워둡시다~ -->

## 🤔 어떤 문제가 발생했나요?

- 애플 로그인 버튼을 연타하면 로그인이 멈추는 현상이 발생합니다.

## 🎉 어떻게 해결했나요?

- 요청이 많이 가서 그런 건지 정확한 원인은 아직 알 수 없으나, 애플 로그인 버튼을 1번 클릭하면 새 창을 열되 disabled 시키는 형태로 방지했습니다. 

### 📷 이미지 첨부 (Option)

**[as is]**


https://github.com/user-attachments/assets/f369fa47-34eb-49c8-be02-ab9987d6f048



**[to be]**


https://github.com/user-attachments/assets/2d07fec4-dbfc-4806-b725-352859480077



### ⚠️ 유의할 점! (Option)

-

<!-- PR merge시 닫을 이슈가 있다면, 번호를 작성해주세요 -->
<!-- Ex) close #12 -->



