### PR TITLE
fix: 애플 로그인 에러 시 모달 띄웁니다.

### DIFF
--- a/app/api/apple/oauth/route.ts
+++ b/app/api/apple/oauth/route.ts
@@ -15,10 +15,10 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
     const userData = formData['user'];
 
     if (!code || !idToken) {
-      return NextResponse.json(
-        { error: 'code 또는 id_token이 누락되었습니다.' },
-        { status: 400 },
-      );
+      const redirectUrl = new URL('/login', request.url);
+      redirectUrl.searchParams.set('login-failed', 'login-failed');
+
+      return NextResponse.redirect(redirectUrl, 302);
     }
 
     const bodyData = {
@@ -39,7 +39,10 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
     );
 
     if (res.status === 401) {
-      return NextResponse.redirect(new URL('/login', request.url), 302);
+      const redirectUrl = new URL('/login', request.url);
+      redirectUrl.searchParams.set('login-failed', 'true');
+
+      return NextResponse.redirect(redirectUrl, 302);
     }
 
     if (!res.ok) {

--- a/app/api/apple/oauth/route.ts
+++ b/app/api/apple/oauth/route.ts
@@ -16,7 +16,7 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
 
     if (!code || !idToken) {
       const redirectUrl = new URL('/login', request.url);
-      redirectUrl.searchParams.set('login-failed', 'login-failed');
+      redirectUrl.searchParams.set('login-failed', 'true');
 
       return NextResponse.redirect(redirectUrl, 302);
     }

--- a/features/login/components/organisms/login-screen.tsx
+++ b/features/login/components/organisms/login-screen.tsx
@@ -2,7 +2,7 @@
 
 import { motion } from 'framer-motion';
 import Image from 'next/image';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 
 import {
   AppleLogoIcon,
@@ -14,11 +14,14 @@ import SwimieLetterLogo from '@/public/images/login/swimie-letter-logo.png';
 import { css, cva } from '@/styled-system/css';
 import { flex } from '@/styled-system/patterns';
 
+import { useLoginFailDialogHandler } from '../../hook/use-login-fail-dialog-handler';
+
 type LoginScreen = {
   isAnimate?: boolean;
 };
 export const LoginScreen = ({ isAnimate = true }: LoginScreen) => {
   const [isAppleLoginDisabled, setIsAppleLoginDisabled] = useState(false);
+  const { openFailModal } = useLoginFailDialogHandler();
 
   const kakaoLogin = () => {
     window.location.href = `https://kauth.kakao.com/oauth/authorize?client_id=${process.env.NEXT_PUBLIC_KAKAO_CLIENT_ID}&redirect_uri=${process.env.NEXT_PUBLIC_KAKAO_REDIRECT_URI}&response_type=code&prompt=select_account`;
@@ -27,11 +30,6 @@ export const LoginScreen = ({ isAnimate = true }: LoginScreen) => {
   // const googleLogin = () => {
   //   window.location.href = `https://accounts.google.com/o/oauth2/v2/auth?client_id=${process.env.NEXT_PUBLIC_GOOGLE_CLIENT_ID}&redirect_uri=${process.env.NEXT_PUBLIC_GOOGLE_REDIRECT_URI}&response_type=code&scope=email profile&prompt=consent&access_type=offline`;
   // };
-
-  const appleLogin = () => {
-    setIsAppleLoginDisabled(true);
-    window.location.href = `https://appleid.apple.com/auth/authorize?client_id=${process.env.NEXT_PUBLIC_APPLE_CLIENT_ID}&redirect_uri=${process.env.NEXT_PUBLIC_APPLE_REDIRECT_URI}&response_type=code id_token&scope=name email&response_mode=form_post`;
-  };
 
   // function generateNonceAndState(length = 16) {
   //   const charset =
@@ -42,6 +40,22 @@ export const LoginScreen = ({ isAnimate = true }: LoginScreen) => {
   //   }
   //   return nonce;
   // }
+
+  const appleLogin = () => {
+    setIsAppleLoginDisabled(true);
+    window.location.href = `https://appleid.apple.com/auth/authorize?client_id=${process.env.NEXT_PUBLIC_APPLE_CLIENT_ID}&redirect_uri=${process.env.NEXT_PUBLIC_APPLE_REDIRECT_URI}&response_type=code id_token&scope=name email&response_mode=form_post`;
+
+    setTimeout(() => {
+      setIsAppleLoginDisabled(false);
+    }, 5000);
+  };
+
+  useEffect(() => {
+    const queryParams = new URLSearchParams(window.location.search);
+    if (queryParams.get('login-failed')) {
+      openFailModal();
+    }
+  }, []);
 
   return (
     <div className={loginPage}>

--- a/features/login/hook/use-login-fail-dialog-handler.ts
+++ b/features/login/hook/use-login-fail-dialog-handler.ts
@@ -1,0 +1,24 @@
+import { useDialog } from '@/hooks';
+
+export function useLoginFailDialogHandler() {
+  const { dialog, close } = useDialog();
+
+  const openFailModal = () => {
+    dialog({
+      title: 'Apple ID 인증이 필요해요.',
+      description:
+        '애플 로그인 시 Face ID 또는 비밀번호를 사용해 로그인을 완료해 주세요.',
+      buttons: {
+        confirm: {
+          label: '확인',
+          onClick: () => {
+            close();
+          },
+        },
+      },
+      isDim: true,
+    });
+  };
+
+  return { openFailModal };
+}


### PR DESCRIPTION
<!-- 작성 예시 -->
<!-- # 어떤 문제가 발생했나요? -->
<!-- - 간략한 문제 설명 -->
<!-- - 문제 관련 링크 등등 -->
<!-- Ex) React v18 version update에 후 테스트에서 에러가 발생합니다.
  라이브러리의 버전이 호환이 되지않아서 문제입니다. -->

<!-- # 어떻게 해결했나요? -->
<!-- - 동작 방식 등 수정힌 코드에 대한 설명 -->
<!-- Ex) 라이브러리의 버전을 업데이트하고, v18을 사용할 수 있도록 dev dependency로 설치해주었습니다. -->

<!-- # 이미지 첨부 (Option) -->
<!-- - 이번 PR의 동작 이해를 돕는 GIF나 이미지 파일 첨부! -->
<!-- - 만약 없다면, NA 혹은 비워둡시다~ -->

<!-- # 유의할 점 (Option) -->
<!-- - 추가적으로 고민중이거나 조언을 구하고 싶은 내용, 어떤 것을 중점으로 리뷰를 해줬으면 좋겠는지 등등 작성 -->
<!-- - 만약 없다면, NA 혹은 비워둡시다~ -->

## 🤔 어떤 문제가 발생했나요?

로그인 에러 시 실패를 받아주는 부분이 누락됨

## 🎉 어떻게 해결했나요?

- 연타 방지를 위해 5초 디바운스
- 에러 401, 400의 경우 /login/login-failed=true 이런 param 붙은 채 이동하고, /login에 왔을 때 저런 param 있으면 dialog 띄워줌 


### 📷 이미지 첨부 (Option)

<img width="353" alt="image" src="https://github.com/user-attachments/assets/09ac2fbc-3f9f-44a9-ba79-d1ccb3bb1d82">

### ⚠️ 유의할 점! (Option)

-

<!-- PR merge시 닫을 이슈가 있다면, 번호를 작성해주세요 -->
<!-- Ex) close #12 -->
